### PR TITLE
Add TCP bridge proxy for Chrome browser sockets

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/richvanbergen/cbox/internal/bridge"
 	"github.com/richvanbergen/cbox/internal/config"
 	"github.com/richvanbergen/cbox/internal/sandbox"
 	"github.com/richvanbergen/cbox/internal/worktree"
@@ -24,6 +25,7 @@ func main() {
 	root.AddCommand(listCmd())
 	root.AddCommand(infoCmd())
 	root.AddCommand(cleanCmd())
+	root.AddCommand(bridgeProxyCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -162,6 +164,18 @@ func cleanCmd() *cobra.Command {
 		Short: "Stop container, remove worktree and branch",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return sandbox.Clean(projectDir())
+		},
+	}
+}
+
+func bridgeProxyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:    "_bridge-proxy [socket-dir]",
+		Short:  "Internal: TCP proxy for Chrome bridge sockets",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bridge.RunProxyCommand(args[0])
 		},
 	}
 }

--- a/internal/bridge/proxy.go
+++ b/internal/bridge/proxy.go
@@ -1,0 +1,187 @@
+package bridge
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// ProxyMapping maps a socket file to the TCP port the proxy is listening on.
+type ProxyMapping struct {
+	SocketName string `json:"socket_name"`
+	TCPPort    int    `json:"tcp_port"`
+}
+
+// proxyState holds the listeners and wait group for a running proxy.
+type proxyState struct {
+	listeners []net.Listener
+	wg        sync.WaitGroup
+	done      chan struct{}
+}
+
+var activeProxy *proxyState
+
+// DiscoverSockets returns the names of all *.sock files in dir.
+func DiscoverSockets(dir string) ([]string, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
+	if err != nil {
+		return nil, fmt.Errorf("globbing sockets: %w", err)
+	}
+	var names []string
+	for _, m := range matches {
+		names = append(names, filepath.Base(m))
+	}
+	return names, nil
+}
+
+// StartProxy discovers Unix sockets in socketDir, opens a TCP listener for each,
+// and bidirectionally copies between TCP connections and the Unix socket.
+// Returns the mappings and any error. The proxy runs in the background until StopProxy is called.
+func StartProxy(socketDir string) ([]ProxyMapping, error) {
+	sockets, err := DiscoverSockets(socketDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(sockets) == 0 {
+		return nil, nil
+	}
+
+	state := &proxyState{
+		done: make(chan struct{}),
+	}
+
+	var mappings []ProxyMapping
+
+	for _, sockName := range sockets {
+		sockPath := filepath.Join(socketDir, sockName)
+
+		// Verify the socket is connectable
+		testConn, err := net.Dial("unix", sockPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: socket %s not connectable, skipping: %v\n", sockName, err)
+			continue
+		}
+		testConn.Close()
+
+		ln, err := net.Listen("tcp", "0.0.0.0:0")
+		if err != nil {
+			return nil, fmt.Errorf("listening TCP for %s: %w", sockName, err)
+		}
+
+		port := ln.Addr().(*net.TCPAddr).Port
+		state.listeners = append(state.listeners, ln)
+		mappings = append(mappings, ProxyMapping{
+			SocketName: sockName,
+			TCPPort:    port,
+		})
+
+		state.wg.Add(1)
+		go func(ln net.Listener, sockPath string) {
+			defer state.wg.Done()
+			for {
+				tcpConn, err := ln.Accept()
+				if err != nil {
+					select {
+					case <-state.done:
+						return
+					default:
+						fmt.Fprintf(os.Stderr, "bridge accept error: %v\n", err)
+						return
+					}
+				}
+
+				go relay(tcpConn, sockPath)
+			}
+		}(ln, sockPath)
+	}
+
+	activeProxy = state
+	return mappings, nil
+}
+
+// StopProxy shuts down the running proxy.
+func StopProxy() {
+	if activeProxy == nil {
+		return
+	}
+
+	close(activeProxy.done)
+	for _, ln := range activeProxy.listeners {
+		ln.Close()
+	}
+	activeProxy.wg.Wait()
+	activeProxy = nil
+}
+
+// relay connects to a Unix socket and bidirectionally copies data with the TCP connection.
+func relay(tcpConn net.Conn, sockPath string) {
+	defer tcpConn.Close()
+
+	unixConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "bridge: failed to connect to %s: %v\n", sockPath, err)
+		return
+	}
+	defer unixConn.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		io.Copy(unixConn, tcpConn)
+		// Signal the other direction to stop
+		if c, ok := unixConn.(*net.UnixConn); ok {
+			c.CloseWrite()
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		io.Copy(tcpConn, unixConn)
+		// Signal the other direction to stop
+		if c, ok := tcpConn.(*net.TCPConn); ok {
+			c.CloseWrite()
+		}
+	}()
+
+	wg.Wait()
+}
+
+// MarshalMappings returns the JSON encoding of the mappings.
+func MarshalMappings(mappings []ProxyMapping) (string, error) {
+	data, err := json.Marshal(mappings)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+// RunProxyCommand is the implementation of the _bridge-proxy hidden command.
+// It starts the proxy, prints mappings as JSON to stdout, then blocks until interrupted.
+func RunProxyCommand(socketDir string) error {
+	mappings, err := StartProxy(socketDir)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(mappings)
+	if err != nil {
+		return err
+	}
+
+	// Print mappings to stdout for the parent process to read
+	fmt.Println(string(data))
+
+	if activeProxy == nil {
+		return nil
+	}
+
+	// Block until proxy is stopped
+	<-activeProxy.done
+	return nil
+}

--- a/internal/docker/templates/Dockerfile.claude.tmpl
+++ b/internal/docker/templates/Dockerfile.claude.tmpl
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y \
-    curl bash git gosu ca-certificates gnupg \
+    curl bash git gosu ca-certificates gnupg socat \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \

--- a/internal/sandbox/state.go
+++ b/internal/sandbox/state.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/richvanbergen/cbox/internal/bridge"
 )
 
 const StateFile = ".cbox.state.json"
@@ -17,7 +19,9 @@ type State struct {
 	Branch          string `json:"branch"`
 	ClaudeImage     string `json:"claude_image"`
 	AppImage        string `json:"app_image"`
-	ProjectDir      string `json:"project_dir"`
+	ProjectDir      string                `json:"project_dir"`
+	BridgeProxyPID  int                   `json:"bridge_proxy_pid,omitempty"`
+	BridgeMappings  []bridge.ProxyMapping `json:"bridge_mappings,omitempty"`
 }
 
 func LoadState(projectDir string) (*State, error) {


### PR DESCRIPTION
## Summary
- Docker for Mac can't forward Unix domain sockets into containers (kernel endpoint is in macOS, not the Linux VM). This replaces the direct `-v` bind-mount with a TCP relay.
- Host side: new `cbox _bridge-proxy` command connects to each `*.sock` and exposes TCP on ephemeral ports
- Container side: `socat` listens on Unix sockets at the expected paths and forwards to `host.docker.internal`

## Changes
- **New:** `internal/bridge/proxy.go` — socket discovery, TCP listeners, bidirectional relay
- **New:** `cbox _bridge-proxy` hidden command in `cmd/cbox/main.go`
- **Modified:** `internal/sandbox/state.go` — added `BridgeProxyPID` and `BridgeMappings` fields
- **Modified:** `internal/sandbox/sandbox.go` — start proxy in `Up()`, stop in `Down()`/`Clean()`
- **Modified:** `internal/docker/container.go` — replaced socket mount with `CHROME_BRIDGE_MAPPINGS` env var
- **Modified:** `Dockerfile.claude.tmpl` — added `socat` package
- **Modified:** `entrypoint.sh` — socat relay setup when mappings are present

## Test plan
- [ ] `go build ./...` and `go vet ./...` pass
- [ ] With Chrome bridge running on host, `cbox up` prints "Starting Chrome bridge proxy..." with port mappings
- [ ] `cbox attach --chat` — Claude Code with `--chrome` connects successfully
- [ ] `cbox down` prints "Stopping Chrome bridge proxy..." and cleans up the process
- [ ] Without Chrome bridge running, `cbox up` skips the proxy silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)