### PR TITLE
Add host command forwarding from container to host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/
+internal/docker/hostcmd-client-linux-*

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
-.PHONY: build install clean
+.PHONY: build install clean hostcmd-client
 
-build:
+HOSTCMD_CLIENT_DIR = internal/docker
+
+hostcmd-client:
+	GOOS=linux GOARCH=amd64 go build -o $(HOSTCMD_CLIENT_DIR)/hostcmd-client-linux-amd64 ./cmd/cbox-host-cmd-client
+	GOOS=linux GOARCH=arm64 go build -o $(HOSTCMD_CLIENT_DIR)/hostcmd-client-linux-arm64 ./cmd/cbox-host-cmd-client
+
+build: hostcmd-client
 	go build -o bin/cbox ./cmd/cbox
 
-install:
+install: hostcmd-client
 	go install ./cmd/cbox
 
 clean:
 	rm -rf bin/
+	rm -f $(HOSTCMD_CLIENT_DIR)/hostcmd-client-linux-*

--- a/cmd/cbox-host-cmd-client/main.go
+++ b/cmd/cbox-host-cmd-client/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync"
+	"syscall"
+
+	"github.com/richvanbergen/cbox/internal/hostcmd"
+)
+
+func main() {
+	cmdName := filepath.Base(os.Args[0])
+	args := os.Args[1:]
+
+	addr := os.Getenv("CBOX_HOST_CMD_ADDR")
+	if addr == "" {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: CBOX_HOST_CMD_ADDR not set\n")
+		os.Exit(1)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: %v\n", err)
+		os.Exit(1)
+	}
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: connect: %v\n", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	// Send handshake
+	req := hostcmd.HandshakeRequest{
+		Cmd:  cmdName,
+		Args: args,
+		Cwd:  cwd,
+	}
+	reqData, _ := json.Marshal(req)
+	reqData = append(reqData, '\n')
+	if _, err := conn.Write(reqData); err != nil {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: handshake write: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Read handshake response
+	reader := bufio.NewReader(conn)
+	respLine, err := reader.ReadBytes('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: handshake read: %v\n", err)
+		os.Exit(1)
+	}
+
+	var resp hostcmd.HandshakeResponse
+	if err := json.Unmarshal(respLine, &resp); err != nil {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: handshake parse: %v\n", err)
+		os.Exit(1)
+	}
+	if resp.Error != "" {
+		fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: %s\n", resp.Error)
+		os.Exit(1)
+	}
+
+	// Trap signals and forward as signal frames
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		for sig := range sigCh {
+			s, ok := sig.(syscall.Signal)
+			if !ok {
+				continue
+			}
+			data := make([]byte, 4)
+			binary.BigEndian.PutUint32(data, uint32(s))
+			hostcmd.WriteFrame(conn, hostcmd.FrameSignal, data)
+		}
+	}()
+
+	var wg sync.WaitGroup
+
+	// Forward local stdin to server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 32*1024)
+		for {
+			n, err := os.Stdin.Read(buf)
+			if n > 0 {
+				if writeErr := hostcmd.WriteFrame(conn, hostcmd.FrameStdin, buf[:n]); writeErr != nil {
+					return
+				}
+			}
+			if err != nil {
+				hostcmd.WriteFrame(conn, hostcmd.FrameStdinEOF, nil)
+				return
+			}
+		}
+	}()
+
+	// Read frames from server
+	exitCode := 1
+	for {
+		frameType, data, err := hostcmd.ReadFrame(reader)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			fmt.Fprintf(os.Stderr, "cbox-host-cmd-client: read frame: %v\n", err)
+			break
+		}
+		switch frameType {
+		case hostcmd.FrameStdout:
+			os.Stdout.Write(data)
+		case hostcmd.FrameStderr:
+			os.Stderr.Write(data)
+		case hostcmd.FrameExitCode:
+			if len(data) >= 4 {
+				exitCode = int(int32(binary.BigEndian.Uint32(data)))
+			}
+			// Terminal frame - done
+			os.Exit(exitCode)
+		}
+	}
+
+	os.Exit(exitCode)
+}

--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/richvanbergen/cbox/internal/bridge"
 	"github.com/richvanbergen/cbox/internal/config"
+	"github.com/richvanbergen/cbox/internal/hostcmd"
 	"github.com/richvanbergen/cbox/internal/sandbox"
 	"github.com/richvanbergen/cbox/internal/worktree"
 	"github.com/spf13/cobra"
@@ -27,6 +28,7 @@ func main() {
 	root.AddCommand(infoCmd())
 	root.AddCommand(cleanCmd())
 	root.AddCommand(bridgeProxyCmd())
+	root.AddCommand(hostCmdProxyCmd())
 
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -196,4 +198,22 @@ func bridgeProxyCmd() *cobra.Command {
 			return bridge.RunProxyCommand(args[0])
 		},
 	}
+}
+
+func hostCmdProxyCmd() *cobra.Command {
+	var worktreePath string
+
+	cmd := &cobra.Command{
+		Use:    "_host-cmd-proxy [commands...]",
+		Short:  "Internal: TCP proxy for host command forwarding",
+		Hidden: true,
+		Args:   cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return hostcmd.RunProxyCommand(args, worktreePath)
+		},
+	}
+
+	cmd.Flags().StringVar(&worktreePath, "worktree", "", "Path to the worktree on the host")
+	cmd.MarkFlagRequired("worktree")
+	return cmd
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,7 +17,8 @@ type Config struct {
 	Env        []string          `yaml:"env,omitempty"`
 	EnvFile    string            `yaml:"env_file,omitempty"`
 	Ports      []string          `yaml:"ports,omitempty"`
-	Browser    bool              `yaml:"browser,omitempty"`
+	Browser      bool              `yaml:"browser,omitempty"`
+	HostCommands []string          `yaml:"host_commands,omitempty"`
 }
 
 func DefaultConfig() *Config {

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -12,6 +12,24 @@ import (
 //go:embed templates/Dockerfile.claude.tmpl templates/entrypoint.sh
 var claudeFiles embed.FS
 
+//go:embed hostcmd-client-linux-amd64
+var hostcmdClientAmd64 []byte
+
+//go:embed hostcmd-client-linux-arm64
+var hostcmdClientArm64 []byte
+
+// HostCmdClientBinary returns the cross-compiled client binary for the given architecture.
+func HostCmdClientBinary(arch string) ([]byte, error) {
+	switch arch {
+	case "amd64":
+		return hostcmdClientAmd64, nil
+	case "arm64":
+		return hostcmdClientArm64, nil
+	default:
+		return nil, fmt.Errorf("unsupported architecture: %s", arch)
+	}
+}
+
 // BuildBaseImage builds the user's production image from their Dockerfile.
 func BuildBaseImage(contextDir, dockerfile, target, imageName string) error {
 	args := []string{"build", "-f", dockerfile, "-t", imageName}

--- a/internal/hostcmd/protocol.go
+++ b/internal/hostcmd/protocol.go
@@ -1,0 +1,63 @@
+package hostcmd
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// Frame types for the wire protocol.
+const (
+	FrameStdin    byte = 0 // client -> server
+	FrameStdout   byte = 1 // server -> client
+	FrameStderr   byte = 2 // server -> client
+	FrameExitCode byte = 3 // server -> client (4-byte int32, terminal)
+	FrameSignal   byte = 4 // client -> server (signal number)
+	FrameStdinEOF byte = 5 // client -> server (0-length)
+)
+
+// HandshakeRequest is sent by the client as a JSON line to initiate a command.
+type HandshakeRequest struct {
+	Cmd  string   `json:"cmd"`
+	Args []string `json:"args"`
+	Cwd  string   `json:"cwd"`
+}
+
+// HandshakeResponse is sent by the server as a JSON line after receiving the request.
+type HandshakeResponse struct {
+	OK    bool   `json:"ok,omitempty"`
+	Error string `json:"error,omitempty"`
+}
+
+// WriteFrame writes a single frame to w: [1-byte type][4-byte big-endian length][data].
+func WriteFrame(w io.Writer, frameType byte, data []byte) error {
+	header := [5]byte{frameType}
+	binary.BigEndian.PutUint32(header[1:], uint32(len(data)))
+	if _, err := w.Write(header[:]); err != nil {
+		return fmt.Errorf("writing frame header: %w", err)
+	}
+	if len(data) > 0 {
+		if _, err := w.Write(data); err != nil {
+			return fmt.Errorf("writing frame data: %w", err)
+		}
+	}
+	return nil
+}
+
+// ReadFrame reads a single frame from r, returning the type and data.
+func ReadFrame(r io.Reader) (byte, []byte, error) {
+	var header [5]byte
+	if _, err := io.ReadFull(r, header[:]); err != nil {
+		return 0, nil, err
+	}
+	frameType := header[0]
+	length := binary.BigEndian.Uint32(header[1:])
+	if length == 0 {
+		return frameType, nil, nil
+	}
+	data := make([]byte, length)
+	if _, err := io.ReadFull(r, data); err != nil {
+		return 0, nil, fmt.Errorf("reading frame data: %w", err)
+	}
+	return frameType, data, nil
+}

--- a/internal/hostcmd/protocol_test.go
+++ b/internal/hostcmd/protocol_test.go
@@ -1,0 +1,86 @@
+package hostcmd
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+func TestWriteAndReadFrame(t *testing.T) {
+	tests := []struct {
+		name      string
+		frameType byte
+		data      []byte
+	}{
+		{"stdout frame", FrameStdout, []byte("hello world")},
+		{"stderr frame", FrameStderr, []byte("error message")},
+		{"stdin frame", FrameStdin, []byte("input data")},
+		{"empty stdin EOF", FrameStdinEOF, nil},
+		{"exit code", FrameExitCode, []byte{0, 0, 0, 0}},
+		{"signal", FrameSignal, []byte{0, 0, 0, 2}},
+		{"large payload", FrameStdout, bytes.Repeat([]byte("x"), 65536)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			if err := WriteFrame(&buf, tt.frameType, tt.data); err != nil {
+				t.Fatalf("WriteFrame: %v", err)
+			}
+
+			gotType, gotData, err := ReadFrame(&buf)
+			if err != nil {
+				t.Fatalf("ReadFrame: %v", err)
+			}
+
+			if gotType != tt.frameType {
+				t.Errorf("frame type = %d, want %d", gotType, tt.frameType)
+			}
+			if !bytes.Equal(gotData, tt.data) {
+				t.Errorf("data length = %d, want %d", len(gotData), len(tt.data))
+			}
+		})
+	}
+}
+
+func TestReadFrameEOF(t *testing.T) {
+	var buf bytes.Buffer
+	_, _, err := ReadFrame(&buf)
+	if err != io.EOF && err != io.ErrUnexpectedEOF {
+		t.Errorf("expected EOF-like error, got %v", err)
+	}
+}
+
+func TestMultipleFrames(t *testing.T) {
+	var buf bytes.Buffer
+
+	frames := []struct {
+		typ  byte
+		data []byte
+	}{
+		{FrameStdout, []byte("line 1\n")},
+		{FrameStderr, []byte("warning\n")},
+		{FrameStdout, []byte("line 2\n")},
+		{FrameExitCode, []byte{0, 0, 0, 0}},
+	}
+
+	for _, f := range frames {
+		if err := WriteFrame(&buf, f.typ, f.data); err != nil {
+			t.Fatalf("WriteFrame: %v", err)
+		}
+	}
+
+	for i, want := range frames {
+		gotType, gotData, err := ReadFrame(&buf)
+		if err != nil {
+			t.Fatalf("ReadFrame[%d]: %v", i, err)
+		}
+		if gotType != want.typ {
+			t.Errorf("frame[%d] type = %d, want %d", i, gotType, want.typ)
+		}
+		if !bytes.Equal(gotData, want.data) {
+			t.Errorf("frame[%d] data mismatch", i)
+		}
+	}
+}

--- a/internal/hostcmd/run.go
+++ b/internal/hostcmd/run.go
@@ -1,0 +1,42 @@
+package hostcmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+// ProxyInfo is printed as JSON to stdout for the parent process to read.
+type ProxyInfo struct {
+	Port int `json:"port"`
+}
+
+// RunProxyCommand starts the host command proxy server, prints port info to stdout,
+// and blocks until SIGTERM. This is the implementation of the _host-cmd-proxy hidden command.
+func RunProxyCommand(commands []string, worktreePath string) error {
+	server := NewServer(commands, worktreePath)
+
+	port, err := server.Start()
+	if err != nil {
+		return err
+	}
+
+	info := ProxyInfo{Port: port}
+	data, err := json.Marshal(info)
+	if err != nil {
+		server.Stop()
+		return err
+	}
+
+	fmt.Println(string(data))
+
+	// Block until interrupted
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	<-sig
+
+	server.Stop()
+	return nil
+}

--- a/internal/hostcmd/server.go
+++ b/internal/hostcmd/server.go
@@ -1,0 +1,259 @@
+package hostcmd
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+)
+
+// Server is a TCP server that proxies whitelisted commands from a container to the host.
+type Server struct {
+	commands    map[string]bool
+	worktreePath string
+	listener    net.Listener
+	wg          sync.WaitGroup
+	done        chan struct{}
+}
+
+// NewServer creates a new host command proxy server.
+func NewServer(commands []string, worktreePath string) *Server {
+	allowed := make(map[string]bool, len(commands))
+	for _, c := range commands {
+		allowed[c] = true
+	}
+	return &Server{
+		commands:    allowed,
+		worktreePath: worktreePath,
+		done:        make(chan struct{}),
+	}
+}
+
+// Start begins listening on a random TCP port. Returns the port number.
+func (s *Server) Start() (int, error) {
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		return 0, fmt.Errorf("listening: %w", err)
+	}
+	s.listener = ln
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				select {
+				case <-s.done:
+					return
+				default:
+					fmt.Fprintf(os.Stderr, "hostcmd accept error: %v\n", err)
+					return
+				}
+			}
+			go s.handleConn(conn)
+		}
+	}()
+
+	return port, nil
+}
+
+// Stop shuts down the server and waits for active connections to finish.
+func (s *Server) Stop() {
+	close(s.done)
+	if s.listener != nil {
+		s.listener.Close()
+	}
+	s.wg.Wait()
+}
+
+// translateCwd converts a container path (/workspace/...) to the host worktree path.
+// Returns an error if the path would escape the worktree.
+func (s *Server) translateCwd(containerCwd string) (string, error) {
+	const containerPrefix = "/workspace"
+	if !strings.HasPrefix(containerCwd, containerPrefix) {
+		return s.worktreePath, nil
+	}
+
+	rel := strings.TrimPrefix(containerCwd, containerPrefix)
+	rel = strings.TrimPrefix(rel, "/")
+
+	if rel == "" {
+		return s.worktreePath, nil
+	}
+
+	hostPath := filepath.Join(s.worktreePath, rel)
+
+	// Ensure the resolved path is within the worktree
+	resolved, err := filepath.Abs(hostPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving path: %w", err)
+	}
+	absWorktree, err := filepath.Abs(s.worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("resolving worktree: %w", err)
+	}
+	if !strings.HasPrefix(resolved, absWorktree) {
+		return "", fmt.Errorf("path %q escapes worktree", containerCwd)
+	}
+
+	return hostPath, nil
+}
+
+func (s *Server) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+
+	// Read handshake (JSON line)
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "hostcmd: reading handshake: %v\n", err)
+		return
+	}
+
+	var req HandshakeRequest
+	if err := json.Unmarshal(line, &req); err != nil {
+		writeHandshakeError(conn, "invalid handshake JSON")
+		return
+	}
+
+	// Validate command against whitelist
+	if !s.commands[req.Cmd] {
+		writeHandshakeError(conn, fmt.Sprintf("command not allowed: %s", req.Cmd))
+		return
+	}
+
+	// Translate cwd
+	hostCwd, err := s.translateCwd(req.Cwd)
+	if err != nil {
+		writeHandshakeError(conn, err.Error())
+		return
+	}
+
+	// Send OK response
+	resp := HandshakeResponse{OK: true}
+	respData, _ := json.Marshal(resp)
+	respData = append(respData, '\n')
+	if _, err := conn.Write(respData); err != nil {
+		return
+	}
+
+	// Spawn the command
+	cmd := exec.Command(req.Cmd, req.Args...)
+	cmd.Dir = hostCwd
+
+	stdinPipe, err := cmd.StdinPipe()
+	if err != nil {
+		sendExitCode(conn, 1)
+		return
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		sendExitCode(conn, 1)
+		return
+	}
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		sendExitCode(conn, 1)
+		return
+	}
+
+	if err := cmd.Start(); err != nil {
+		sendExitCode(conn, 127)
+		return
+	}
+
+	var ioWg sync.WaitGroup
+
+	// Forward stdout -> client
+	ioWg.Add(1)
+	go func() {
+		defer ioWg.Done()
+		pipeToFrames(conn, stdoutPipe, FrameStdout)
+	}()
+
+	// Forward stderr -> client
+	ioWg.Add(1)
+	go func() {
+		defer ioWg.Done()
+		pipeToFrames(conn, stderrPipe, FrameStderr)
+	}()
+
+	// Read frames from client (stdin data, signals, EOF)
+	ioWg.Add(1)
+	go func() {
+		defer ioWg.Done()
+		for {
+			frameType, data, err := ReadFrame(reader)
+			if err != nil {
+				stdinPipe.Close()
+				return
+			}
+			switch frameType {
+			case FrameStdin:
+				stdinPipe.Write(data)
+			case FrameStdinEOF:
+				stdinPipe.Close()
+			case FrameSignal:
+				if len(data) >= 4 && cmd.Process != nil {
+					sig := syscall.Signal(binary.BigEndian.Uint32(data))
+					cmd.Process.Signal(sig)
+				}
+			}
+		}
+	}()
+
+	// Wait for command to finish
+	err = cmd.Wait()
+	ioWg.Wait()
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+		}
+	}
+	sendExitCode(conn, exitCode)
+}
+
+func writeHandshakeError(conn net.Conn, msg string) {
+	resp := HandshakeResponse{Error: msg}
+	data, _ := json.Marshal(resp)
+	data = append(data, '\n')
+	conn.Write(data)
+}
+
+func sendExitCode(conn net.Conn, code int) {
+	data := make([]byte, 4)
+	binary.BigEndian.PutUint32(data, uint32(int32(code)))
+	WriteFrame(conn, FrameExitCode, data)
+}
+
+func pipeToFrames(conn net.Conn, r io.Reader, frameType byte) {
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			if writeErr := WriteFrame(conn, frameType, buf[:n]); writeErr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}

--- a/internal/hostcmd/server_test.go
+++ b/internal/hostcmd/server_test.go
@@ -1,0 +1,58 @@
+package hostcmd
+
+import (
+	"testing"
+)
+
+func TestTranslateCwd(t *testing.T) {
+	s := NewServer([]string{"git"}, "/host/path/to/worktree")
+
+	tests := []struct {
+		name       string
+		input      string
+		want       string
+		wantErr    bool
+	}{
+		{"workspace root", "/workspace", "/host/path/to/worktree", false},
+		{"workspace subdir", "/workspace/src", "/host/path/to/worktree/src", false},
+		{"workspace nested", "/workspace/src/pkg/foo", "/host/path/to/worktree/src/pkg/foo", false},
+		{"non-workspace path", "/home/claude", "/host/path/to/worktree", false},
+		{"workspace with trailing slash", "/workspace/", "/host/path/to/worktree", false},
+		{"path traversal", "/workspace/../etc/passwd", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := s.translateCwd(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("translateCwd(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWhitelist(t *testing.T) {
+	s := NewServer([]string{"git", "gh"}, "/tmp/worktree")
+
+	if !s.commands["git"] {
+		t.Error("git should be allowed")
+	}
+	if !s.commands["gh"] {
+		t.Error("gh should be allowed")
+	}
+	if s.commands["rm"] {
+		t.Error("rm should not be allowed")
+	}
+	if s.commands[""] {
+		t.Error("empty string should not be allowed")
+	}
+}

--- a/internal/sandbox/state.go
+++ b/internal/sandbox/state.go
@@ -20,8 +20,10 @@ type State struct {
 	ClaudeImage     string `json:"claude_image"`
 	AppImage        string `json:"app_image"`
 	ProjectDir      string                `json:"project_dir"`
-	BridgeProxyPID  int                   `json:"bridge_proxy_pid,omitempty"`
-	BridgeMappings  []bridge.ProxyMapping `json:"bridge_mappings,omitempty"`
+	BridgeProxyPID   int                   `json:"bridge_proxy_pid,omitempty"`
+	BridgeMappings   []bridge.ProxyMapping `json:"bridge_mappings,omitempty"`
+	HostCmdProxyPID  int                   `json:"host_cmd_proxy_pid,omitempty"`
+	HostCmdProxyPort int                   `json:"host_cmd_proxy_port,omitempty"`
 }
 
 func LoadState(projectDir string) (*State, error) {


### PR DESCRIPTION
## Summary

- Adds a TCP proxy that forwards whitelisted commands from the Claude container to the host machine, allowing Claude to use host-side tools (e.g. `git`, `gh`) transparently
- Uses a framed binary wire protocol over a single TCP port shared by all commands
- Client binary inside the container is symlinked as each command name, determines which command to run from `argv[0]`

## Configuration

Add `host_commands` to `.cbox.yml`:

```yaml
host_commands:
  - git
  - gh
```

## Architecture

```
Claude Container                      Host
/home/claude/bin/git (symlink)        cbox _host-cmd-proxy (TCP server)
  -> .cbox-host-cmd-client            validates command against whitelist
  -> TCP host.docker.internal:PORT    translates CWD, spawns process, streams I/O
```

## What changed

### New files

| File | Purpose |
|------|---------|
| `internal/hostcmd/protocol.go` | Shared frame read/write functions and handshake types. Frame format: `[1-byte type][4-byte big-endian length][data]`. Types: stdin(0), stdout(1), stderr(2), exit code(3), signal(4), stdin EOF(5). |
| `internal/hostcmd/server.go` | TCP server that accepts connections, reads JSON handshake, validates command against whitelist, translates CWD (`/workspace/X` -> `<worktree>/X` with path traversal protection), spawns the host process, and bidirectionally streams I/O via frames. |
| `internal/hostcmd/run.go` | `RunProxyCommand` entry point -- starts server, prints `{"port":N}` to stdout, blocks until SIGTERM. Same lifecycle pattern as `bridge.RunProxyCommand`. |
| `cmd/cbox-host-cmd-client/main.go` | Standalone binary deployed into the container. Reads command name from `filepath.Base(os.Args[0])`, connects to `CBOX_HOST_CMD_ADDR`, performs JSON handshake, enters frame loop for stdin/stdout/stderr forwarding, traps SIGINT/SIGTERM and forwards as signal frames, exits with remote process's exit code. |
| `internal/hostcmd/protocol_test.go` | Tests for frame read/write roundtripping, EOF handling, multi-frame sequences. |
| `internal/hostcmd/server_test.go` | Tests for CWD translation (including path traversal rejection) and whitelist validation. |

### Modified files

| File | Change |
|------|--------|
| `internal/config/config.go` | Added `HostCommands []string` field to `Config` struct |
| `internal/sandbox/state.go` | Added `HostCmdProxyPID int` and `HostCmdProxyPort int` to persisted state |
| `internal/sandbox/sandbox.go` | Start host command proxy in `Up()` between bridge proxy and Claude container start; stop proxy in `Down()` and `Clean()`; install client binary + symlinks after container starts; new `startHostCmdProxy()` helper |
| `internal/docker/container.go` | `RunClaudeContainer` accepts `hostCmdPort` param, sets `CBOX_HOST_CMD_ADDR` env var; new `InstallHostCommands()` (writes binary, creates symlinks) and `DetectContainerArch()` functions |
| `internal/docker/build.go` | Embeds cross-compiled client binaries via `//go:embed`; `HostCmdClientBinary(arch)` selector for amd64/arm64 |
| `cmd/cbox/main.go` | Registered hidden `_host-cmd-proxy` command with `--worktree` flag |
| `Makefile` | Cross-compile client binary for linux/amd64 and linux/arm64 as a prerequisite of `build` and `install` |
| `.gitignore` | Added `internal/docker/hostcmd-client-linux-*` |

## Wire protocol

**Handshake** (JSON lines, before framed I/O begins):
```
Client -> Server: {"cmd":"git","args":["status"],"cwd":"/workspace/src"}\n
Server -> Client: {"ok":true}\n
```

**Framed I/O** (after handshake):
```
[1-byte type][4-byte big-endian uint32 length][data]
```
- Type 0: stdin (client->server)
- Type 1: stdout (server->client)
- Type 2: stderr (server->client)
- Type 3: exit code (server->client, 4-byte int32, terminal frame)
- Type 4: signal (client->server, 4-byte signal number)
- Type 5: stdin EOF (client->server, 0-length)

## Limitations (v1)

- No TTY forwarding -- interactive commands that need a terminal (e.g. `git commit` opening an editor) won't work
- Host process inherits the proxy's environment, no per-command env overrides
- TCP port bound to `0.0.0.0` (matches existing bridge proxy behavior)

## Manual verification

### Prerequisites
- Build with `make build`
- Have a project with a valid `.cbox.yml` and Dockerfile

### Steps

1. Add host commands to `.cbox.yml`:
   ```yaml
   host_commands:
     - echo
     - git
   ```

2. Start the sandbox:
   ```
   cbox up
   ```
   Verify output includes:
   ```
   Starting host command proxy...
     Host command proxy on port XXXXX for: echo, git
   Installing host command forwarding for: echo, git
   ```

3. Shell into the Claude container:
   ```
   cbox shell
   ```

4. Inside the container, verify commands resolve to the proxy client:
   ```
   which git        # should show /home/claude/bin/git
   ls -la /home/claude/bin/git  # should be a symlink to .cbox-host-cmd-client
   ```

5. Test command execution:
   ```
   echo hello           # should print "hello" (executed on host)
   git status           # should show host worktree status
   git log --oneline -5 # should show host repo history
   echo $?              # should be 0
   ```

6. Test exit codes:
   ```
   git log --oneline --invalid-flag 2>/dev/null; echo $?  # should be non-zero
   ```

7. Test that non-whitelisted commands use the container's version:
   ```
   which ls  # should NOT be /home/claude/bin/ls
   ```

8. Stop the sandbox:
   ```
   cbox down
   ```
   Verify output includes "Stopping host command proxy..."

9. Verify proxy process is gone:
   ```
   # The PID from .cbox.state.json should no longer be running
   ```

## Test plan

- [x] Unit tests for frame read/write roundtripping
- [x] Unit tests for CWD translation and path traversal rejection
- [x] Unit tests for whitelist validation
- [ ] Manual: `cbox up` starts proxy and installs symlinks
- [ ] Manual: Commands execute on host and return correct output
- [ ] Manual: Exit codes are forwarded correctly
- [ ] Manual: Non-whitelisted commands are unaffected
- [ ] Manual: `cbox down` stops the proxy process

🤖 Generated with [Claude Code](https://claude.com/claude-code)