### PR TITLE
Remove app container, make commands MCP tools

### DIFF
--- a/.cbox.yml
+++ b/.cbox.yml
@@ -1,6 +1,9 @@
-dockerfile: ./Dockerfile
+commands:
+    build: go build -o bin/cbox ./cmd/cbox
+    test: go test ./...
+    run: go run ./cmd/cbox
 env:
-  - ANTHROPIC_API_KEY
+    - ANTHROPIC_API_KEY
 host_commands:
-  - git
-  - gh
+    - git
+    - gh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CBox
+
+## Build
+
+```
+go build -o bin/cbox ./cmd/cbox
+```

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
 # cbox
 
-Sandboxed development environments for Claude Code. Each sandbox runs two containers sharing a workspace volume — Claude never touches your production image.
+Sandboxed development environments for Claude Code. Each sandbox runs a Claude container with your workspace mounted, and exposes project commands as MCP tools that run on the host.
 
 ## Architecture
 
 ```
-Claude Container              App Container
-(debian + Claude CLI)         (your Dockerfile)
+Host Machine                    Claude Container
+                                (debian + Claude CLI)
+  MCP Server
+    cbox_build ──sh -c──>       calls via MCP tool
+    cbox_test  ──sh -c──>       calls via MCP tool
+    run_command (git, gh)       calls via MCP tool
 
-  cbox-run  ──docker exec──>  bun run index.ts
-  cbox-test ──docker exec──>  bun test
-
-  /workspace (mount)          /workspace (mount)
-  docker.sock (mount)         ports exposed
+                                /workspace (mount)
+                                docker.sock (mount)
 ```
 
-- **Claude container** — Fixed Debian image with Claude Code CLI and Docker client. `cbox chat` connects here. Has generated wrapper scripts (`cbox-run`, `cbox-test`, etc.) that execute commands in the app container.
-- **App container** — Your Dockerfile built unmodified, started with `sleep infinity`. Named commands from `.cbox.yml` run inside it.
-- **Workspace** — A git worktree mounted into both containers. Each branch gets its own isolated worktree.
+- **Claude container** — Fixed Debian image with Claude Code CLI. `cbox chat` connects here.
+- **MCP server** — Runs on the host, exposes named commands (`cbox_build`, `cbox_test`, etc.) and whitelisted host commands (`git`, `gh`) as MCP tools. Claude calls these tools from inside the container.
+- **Workspace** — A git worktree mounted into the container. Each branch gets its own isolated worktree.
 
 ## Install
 
@@ -42,45 +43,37 @@ cd your-project
 
 # Create config
 cbox init
-# Edit .cbox.yml to add commands, ports, etc.
+# Edit .cbox.yml to set your build/test commands
 
 # Start sandbox on a new branch
-cbox up --branch feat-my-feature
+cbox up feat-my-feature
 
 # Start Claude
-cbox chat
+cbox chat feat-my-feature
 
 # Run a one-shot prompt
-cbox chat -p "refactor the auth module"
+cbox chat feat-my-feature -p "refactor the auth module"
 
-# Shell into the app container
-cbox exec
+# Shell into the Claude container (for debugging)
+cbox shell feat-my-feature
 
-# Run a command in the app container
-cbox exec npm test
-
-# Stop containers (keeps worktree)
-cbox down
+# Stop container (keeps worktree)
+cbox down feat-my-feature
 
 # Full cleanup (removes worktree and branch)
-cbox clean
+cbox clean feat-my-feature
 ```
 
 ## Configuration
 
-Create `.cbox.yml` in your project root:
+Create `.cbox.yml` in your project root (`cbox init` generates a starter config):
 
 ```yaml
-dockerfile: ./Dockerfile
-target: release              # optional multi-stage build target
 commands:
-  run: "bun run index.ts"
-  test: "bun test"
-  build: "bun build ./index.ts --outdir ./dist"
+  build: "npm run build"
+  test: "npm test"
 env:
   - ANTHROPIC_API_KEY        # read from host environment
-ports:
-  - "3000:3000"
 host_commands:
   - git
   - gh
@@ -90,63 +83,69 @@ host_commands:
 
 | Field | Description |
 |---|---|
-| `dockerfile` | Path to your Dockerfile |
-| `target` | Multi-stage build target (optional) |
-| `commands` | Named commands that become `cbox-<name>` scripts in the Claude container |
-| `env` | Environment variable names to pass from host |
+| `commands` | Named commands exposed as `cbox_<name>` MCP tools (run on the host via `sh -c`) |
+| `env` | Environment variable names to pass from host into the Claude container |
 | `env_file` | Path to an env file |
-| `ports` | Port mappings for the app container |
-| `host_commands` | Commands Claude can run on the host via MCP (e.g. `git`, `gh`) |
+| `browser` | Enable Chrome bridge for browser-aware Claude sessions |
+| `host_commands` | Commands Claude can run on the host via the `run_command` MCP tool (e.g. `git`, `gh`) |
 
 ## Commands
 
 ### `cbox init`
 
-Creates a default `.cbox.yml` in the current directory.
+Creates a default `.cbox.yml` in the current directory with placeholder `build` and `test` commands, and `git`/`gh` as default host commands.
 
-### `cbox up --branch <name>`
+### `cbox up <branch>`
 
-Creates a git worktree, builds both images, creates a Docker network, and starts both containers. Idempotent — re-running replaces existing containers.
+Creates a git worktree, builds the Claude image, creates a Docker network, and starts the Claude container. If `commands` or `host_commands` are configured, starts an MCP server on the host. Idempotent — re-running replaces the existing container.
 
-### `cbox down`
+### `cbox down <branch>`
 
-Stops both containers and removes the network. Preserves the worktree so you can `cbox up` again.
+Stops the container, MCP server, and removes the network. Preserves the worktree so you can `cbox up` again.
 
-### `cbox chat`
+### `cbox chat <branch>`
 
 Launches Claude Code interactively in the Claude container.
 
-### `cbox chat -p "<prompt>"`
+### `cbox chat <branch> -p "<prompt>"`
 
 Runs a one-shot Claude prompt in the Claude container (headless, JSON output).
 
-### `cbox exec [command...]`
+### `cbox shell <branch>`
 
-Runs a command in the app container. With no arguments, opens an interactive shell (prefers bash, falls back to sh).
+Opens a bash shell in the Claude container. Useful for debugging.
 
-### `cbox shell`
+### `cbox list`
 
-Opens a bash shell in the Claude container. Useful for debugging the Claude container itself.
+Lists all tracked sandboxes and their status.
 
-### `cbox clean`
+### `cbox info <branch>`
 
-Stops containers, removes the network, deletes the worktree, and removes the branch.
+Shows details about a specific sandbox (container name, network, worktree path).
+
+### `cbox clean <branch>`
+
+Stops the container, removes the network, deletes the worktree, and removes the branch.
 
 ## How named commands work
 
-Each entry in `commands` becomes a script at `/home/claude/bin/cbox-<name>` inside the Claude container. When Claude (or you) runs `cbox-run`, it executes:
+Each entry in `commands` becomes a dedicated MCP tool named `cbox_<name>`. When Claude calls the tool, the MCP server on the host runs `sh -c '<expression>'` in the worktree directory.
 
-```bash
-docker exec -i <app-container> sh -c 'bun run index.ts'
+For example, with this config:
+
+```yaml
+commands:
+  test: "npm test"
+  build: "npm run build"
 ```
 
-This keeps the Claude container decoupled from your app's runtime — it only needs the Docker CLI to dispatch commands.
+Claude sees two MCP tools: `cbox_test` and `cbox_build`. Calling `cbox_test` runs `sh -c 'npm test'` on the host in the worktree directory.
 
 ## Host commands
 
-Claude inside the container doesn't have access to host tools like `git` or `gh`. The `host_commands` config whitelists commands that Claude can run on the host machine via an MCP server.
+Claude inside the container doesn't have access to host tools like `git` or `gh`. The `host_commands` config whitelists commands that Claude can run on the host machine via the `run_command` MCP tool.
 
-When `host_commands` is set, `cbox up` starts an MCP server on the host that exposes a `run_command` tool. Claude Code in the container connects to it automatically via `.mcp.json`. A system-level `CLAUDE.md` is also injected to tell Claude to use the MCP tool instead of running these commands directly.
+When `host_commands` or `commands` are configured, `cbox up` starts an MCP server on the host. Claude Code in the container connects to it automatically via `.mcp.json`. A system-level `CLAUDE.md` is also injected to tell Claude how to use the available tools.
 
 ```yaml
 host_commands:
@@ -154,7 +153,7 @@ host_commands:
   - gh
 ```
 
-With this config, Claude can run `git status`, `gh pr create`, etc. on the host. Commands not in the whitelist are rejected — Claude will tell the user to add the command to `host_commands` in `.cbox.yml`.
+With this config, Claude can run `git status`, `gh pr create`, etc. on the host via the `run_command` tool. Commands not in the whitelist are rejected.
 
 Path arguments containing `/workspace/...` are automatically translated to the host worktree path, and paths outside the worktree are rejected.
 
@@ -162,9 +161,10 @@ Path arguments containing `/workspace/...` are automatically translated to the h
 
 Per sandbox, cbox creates:
 
-- 2 containers: `cbox-<project>-<branch>-claude` and `cbox-<project>-<branch>-app`
+- 1 container: `cbox-<project>-<branch>-claude`
 - 1 bridge network: `cbox-<project>-<branch>`
-- 2 images: `cbox-<project>:claude` and `cbox-<project>:app`
+- 1 image: `cbox-<project>:claude`
 - 1 git worktree directory
+- 1 MCP server process (if commands or host_commands are configured)
 
 All are cleaned up by `cbox clean`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,20 +11,22 @@ import (
 const ConfigFile = ".cbox.yml"
 
 type Config struct {
-	Dockerfile string            `yaml:"dockerfile"`
-	Target     string            `yaml:"target,omitempty"`
-	Commands   map[string]string `yaml:"commands,omitempty"`
-	Env        []string          `yaml:"env,omitempty"`
-	EnvFile    string            `yaml:"env_file,omitempty"`
-	Ports        []string          `yaml:"ports,omitempty"`
+	Commands     map[string]string `yaml:"commands,omitempty"`
+	Env          []string          `yaml:"env,omitempty"`
+	EnvFile      string            `yaml:"env_file,omitempty"`
 	Browser      bool              `yaml:"browser,omitempty"`
 	HostCommands []string          `yaml:"host_commands,omitempty"`
 }
 
 func DefaultConfig() *Config {
 	return &Config{
-		Dockerfile: "./Dockerfile",
-		Env:        []string{"ANTHROPIC_API_KEY"},
+		Commands: map[string]string{
+			"build": "echo 'TODO: set your build command'",
+			"test":  "echo 'TODO: set your test command'",
+			"run":   "echo 'TODO: set your run command'",
+		},
+		Env:          []string{"ANTHROPIC_API_KEY"},
+		HostCommands: []string{"git", "gh"},
 	}
 }
 

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -12,23 +12,6 @@ import (
 //go:embed templates/Dockerfile.claude.tmpl templates/entrypoint.sh
 var claudeFiles embed.FS
 
-// BuildBaseImage builds the user's production image from their Dockerfile.
-func BuildBaseImage(contextDir, dockerfile, target, imageName string) error {
-	args := []string{"build", "-f", dockerfile, "-t", imageName}
-	if target != "" {
-		args = append(args, "--target", target)
-	}
-	args = append(args, contextDir)
-
-	cmd := exec.Command("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("building base image: %w", err)
-	}
-	return nil
-}
-
 // BuildClaudeImage builds the Claude container image from the embedded template.
 func BuildClaudeImage(imageName string) error {
 	tmpDir, err := os.MkdirTemp("", "cbox-")

--- a/internal/hostcmd/run.go
+++ b/internal/hostcmd/run.go
@@ -14,8 +14,8 @@ type proxyOutput struct {
 }
 
 // RunProxyCommand starts the MCP server, prints the port as JSON, and blocks until signaled.
-func RunProxyCommand(worktreePath string, commands []string) error {
-	srv := NewServer(worktreePath, commands)
+func RunProxyCommand(worktreePath string, commands []string, namedCommands map[string]string) error {
+	srv := NewServer(worktreePath, commands, namedCommands)
 
 	port, err := srv.Start()
 	if err != nil {

--- a/internal/sandbox/state.go
+++ b/internal/sandbox/state.go
@@ -13,13 +13,11 @@ import (
 const StateDir = ".cbox"
 
 type State struct {
-	ClaudeContainer string `json:"claude_container"`
-	AppContainer    string `json:"app_container"`
-	NetworkName     string `json:"network_name"`
-	WorktreePath    string `json:"worktree_path"`
-	Branch          string `json:"branch"`
-	ClaudeImage     string `json:"claude_image"`
-	AppImage        string `json:"app_image"`
+	ClaudeContainer string                `json:"claude_container"`
+	NetworkName     string                `json:"network_name"`
+	WorktreePath    string                `json:"worktree_path"`
+	Branch          string                `json:"branch"`
+	ClaudeImage     string                `json:"claude_image"`
 	ProjectDir      string                `json:"project_dir"`
 	Running         bool                  `json:"running"`
 	BridgeProxyPID  int                   `json:"bridge_proxy_pid,omitempty"`


### PR DESCRIPTION
## Summary

- Remove the app container concept entirely — CBox now only runs the Claude container
- Named commands (`build`, `test`, etc.) become dedicated MCP tools (`cbox_build`, `cbox_test`) that execute on the host via `sh -c`
- `cbox exec` CLI command removed (no app container to exec into)
- `DefaultConfig()` now includes placeholder `build`/`test` commands and `git`/`gh` as default host commands
- README rewritten to reflect the new single-container MCP architecture

## Config changes

Removed fields: `dockerfile`, `target`, `ports`

New default `.cbox.yml` from `cbox init`:
```yaml
commands:
    build: echo 'TODO: set your build command'
    test: echo 'TODO: set your test command'
env:
    - ANTHROPIC_API_KEY
host_commands:
    - git
    - gh
```

## Test plan

- [x] Build: `go build -o bin/cbox ./cmd/cbox`
- [x] Unit tests: `go test ./...` (includes new named command MCP tool tests)
- [x] Manual test — init:
  1. `cd /tmp && mkdir test-project && cd test-project && git init`
  2. `cbox init`
  3. Verify `.cbox.yml` contains `commands.build`, `commands.test`, and `host_commands: [git, gh]`
- [x] Manual test — named commands as MCP tools:
  1. Create a `.cbox.yml` with `commands: { test: "echo hello" }` and `host_commands: [git]`
  2. `cbox up test-branch`
  3. `cbox chat test-branch`
  4. Verify Claude sees `cbox_test` and `run_command` MCP tools
  5. Ask Claude to run the test command — should see "hello" output
  6. Ask Claude to run `git status` — should work via `run_command`
- [x] Manual test — cleanup:
  1. `cbox down test-branch` — container stops, no errors about missing app container
  2. `cbox clean test-branch` — full cleanup succeeds
- [x] Verify `cbox exec` is no longer a valid command (should show help/error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)