### PR TITLE
Add cbox eject command and --rebuild flag

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	EnvFile      string            `yaml:"env_file,omitempty"`
 	Browser      bool              `yaml:"browser,omitempty"`
 	HostCommands []string          `yaml:"host_commands,omitempty"`
+	Dockerfile   string            `yaml:"dockerfile,omitempty"`
 }
 
 func DefaultConfig() *Config {

--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -12,40 +12,68 @@ import (
 //go:embed templates/Dockerfile.claude.tmpl templates/entrypoint.sh
 var claudeFiles embed.FS
 
-// BuildClaudeImage builds the Claude container image from the embedded template.
-func BuildClaudeImage(imageName string) error {
+// BuildOptions controls how the Claude image is built.
+type BuildOptions struct {
+	ProjectDockerfile string // absolute path to a custom Dockerfile; empty = use embedded
+	NoCache           bool   // pass --no-cache to docker build
+}
+
+// BuildClaudeImage builds the Claude container image from the embedded template
+// or a custom Dockerfile specified in opts.
+func BuildClaudeImage(imageName string, opts BuildOptions) error {
 	tmpDir, err := os.MkdirTemp("", "cbox-")
 	if err != nil {
 		return fmt.Errorf("creating temp dir: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Write all embedded files into the build context
-	files := []struct{ embed, local string }{
-		{"templates/Dockerfile.claude.tmpl", "Dockerfile.claude"},
-		{"templates/entrypoint.sh", "entrypoint.sh"},
+	// Always extract embedded entrypoint.sh into the build context
+	entrypoint, err := claudeFiles.ReadFile("templates/entrypoint.sh")
+	if err != nil {
+		return fmt.Errorf("reading embedded entrypoint.sh: %w", err)
 	}
-	for _, f := range files {
-		data, err := claudeFiles.ReadFile(f.embed)
-		if err != nil {
-			return fmt.Errorf("reading embedded %s: %w", f.embed, err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, f.local), data, 0755); err != nil {
-			return fmt.Errorf("writing %s: %w", f.local, err)
-		}
+	if err := os.WriteFile(filepath.Join(tmpDir, "entrypoint.sh"), entrypoint, 0755); err != nil {
+		return fmt.Errorf("writing entrypoint.sh: %w", err)
 	}
 
-	cmd := exec.Command("docker", "build",
+	// Resolve Dockerfile content: custom or embedded
+	var dockerfileData []byte
+	if opts.ProjectDockerfile != "" {
+		dockerfileData, err = os.ReadFile(opts.ProjectDockerfile)
+		if err != nil {
+			return fmt.Errorf("reading custom Dockerfile %s: %w", opts.ProjectDockerfile, err)
+		}
+	} else {
+		dockerfileData, err = claudeFiles.ReadFile("templates/Dockerfile.claude.tmpl")
+		if err != nil {
+			return fmt.Errorf("reading embedded Dockerfile: %w", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "Dockerfile.claude"), dockerfileData, 0644); err != nil {
+		return fmt.Errorf("writing Dockerfile.claude: %w", err)
+	}
+
+	buildArgs := []string{"build",
 		"-f", filepath.Join(tmpDir, "Dockerfile.claude"),
 		"-t", imageName,
-		tmpDir,
-	)
+	}
+	if opts.NoCache {
+		buildArgs = append(buildArgs, "--no-cache")
+	}
+	buildArgs = append(buildArgs, tmpDir)
+
+	cmd := exec.Command("docker", buildArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("building claude image: %w", err)
 	}
 	return nil
+}
+
+// EmbeddedDockerfile returns the contents of the embedded Dockerfile template.
+func EmbeddedDockerfile() ([]byte, error) {
+	return claudeFiles.ReadFile("templates/Dockerfile.claude.tmpl")
 }
 
 // ImageName returns a sanitized image name from the project name.

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -16,7 +16,8 @@ import (
 )
 
 // Up creates a worktree, builds the Claude image, creates a network, and starts the Claude container.
-func Up(projectDir, branch string) error {
+// If rebuild is true, the image is built with --no-cache.
+func Up(projectDir, branch string, rebuild bool) error {
 	cfg, err := config.Load(projectDir)
 	if err != nil {
 		return err
@@ -35,7 +36,11 @@ func Up(projectDir, branch string) error {
 	// 2. Build Claude image
 	claudeImage := docker.ImageName(projectName, "claude")
 	fmt.Printf("Building Claude image %s...\n", claudeImage)
-	if err := docker.BuildClaudeImage(claudeImage); err != nil {
+	buildOpts := docker.BuildOptions{NoCache: rebuild}
+	if cfg.Dockerfile != "" {
+		buildOpts.ProjectDockerfile = filepath.Join(projectDir, cfg.Dockerfile)
+	}
+	if err := docker.BuildClaudeImage(claudeImage, buildOpts); err != nil {
 		return fmt.Errorf("building claude image: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Add `cbox eject` command that copies the embedded Dockerfile to `Dockerfile.cbox` for customization, and updates `.cbox.yml` with a `dockerfile` field pointing to it
- Add `--rebuild` flag to `cbox up` that passes `--no-cache` to `docker build` for forcing clean rebuilds
- Refactor `BuildClaudeImage` to accept `BuildOptions` supporting custom Dockerfiles and no-cache builds

## Test plan
- [x] `go build -o bin/cbox ./cmd/cbox` compiles successfully
- [x] `go test ./...` passes
- [x] `cbox init` in a fresh project creates `.cbox.yml`
- [x] `cbox eject` creates `Dockerfile.cbox` with header comment and updates `.cbox.yml` with `dockerfile: Dockerfile.cbox`
- [x] `cbox eject` a second time fails with "already ejected" error
- [x] `cbox up <branch>` still works without eject (uses embedded Dockerfile)
- [x] `cbox up <branch> --rebuild` builds with `--no-cache` (verify in docker build output)
- [x] After eject, `cbox up <branch>` uses the custom `Dockerfile.cbox`
- [x] Editing `Dockerfile.cbox` and running `cbox up --rebuild <branch>` picks up the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)