### PR TITLE
Add shell completion for bash, zsh, and fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,43 @@ go build -o bin/cbox ./cmd/cbox
 
 Requires Docker.
 
+## Shell Completion
+
+cbox supports shell completion for bash, zsh, and fish. Completions include commands, flags, git branches, and config-defined commands.
+
+### Bash
+
+```bash
+# Load for current session
+source <(cbox completion bash)
+
+# Install permanently (Linux)
+cbox completion bash > /etc/bash_completion.d/cbox
+
+# Install permanently (macOS with Homebrew)
+cbox completion bash > $(brew --prefix)/etc/bash_completion.d/cbox
+```
+
+### Zsh
+
+```bash
+# Enable completion (add to ~/.zshrc if not already enabled)
+autoload -U compinit; compinit
+
+# Install completion
+cbox completion zsh > "${fpath[1]}/_cbox"
+```
+
+### Fish
+
+```fish
+# Load for current session
+cbox completion fish | source
+
+# Install permanently
+cbox completion fish > ~/.config/fish/completions/cbox.fish
+```
+
 ## Quick start
 
 ```bash
@@ -126,6 +163,10 @@ Shows details about a specific sandbox (container name, network, worktree path).
 ### `cbox clean <branch>`
 
 Stops the container, removes the network, deletes the worktree, and removes the branch.
+
+### `cbox completion [bash|zsh|fish]`
+
+Generates shell completion scripts. See [Shell Completion](#shell-completion) for installation instructions.
 
 ## How named commands work
 


### PR DESCRIPTION
## Summary

- Add `cbox completion [bash|zsh|fish]` command to generate shell completion scripts
- Add dynamic completion for git branches on commands that take a `<branch>` argument (up, down, chat, shell, info, clean)
- Add dynamic completion for config-defined commands on `cbox run`
- Document shell completion setup in README

## Features

When users press Tab:
- `cbox <TAB>` → shows all subcommands
- `cbox up <TAB>` → shows git branches
- `cbox chat feat<TAB>` → completes to branches starting with "feat"
- `cbox run <TAB>` → shows commands defined in `.cbox.yml`
- `cbox completion <TAB>` → shows `bash`, `zsh`, `fish`

## Test plan

- [ ] Build the project: `go build -o bin/cbox ./cmd/cbox`
- [ ] Test bash completion: `source <(./bin/cbox completion bash)` then `cbox <TAB>`
- [ ] Test zsh completion: `source <(./bin/cbox completion zsh)` then `cbox <TAB>`
- [ ] Test fish completion: `./bin/cbox completion fish | source` then `cbox <TAB>`
- [ ] Verify branch completion works for `cbox up <TAB>`
- [ ] Verify command completion works for `cbox run <TAB>` (with a `.cbox.yml` present)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)