### PR TITLE
Restructure .cbox-task to structured YAML

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,14 +62,14 @@ func DefaultWorkflowConfig() *WorkflowConfig {
 		Branch: "{{.Slug}}",
 		Issue: &WorkflowIssueConfig{
 			Create:    `gh issue create --title "$Title" --body "$Description" | grep -o '[0-9]*$'`,
-			View:      `gh issue view "$IssueID" --json title,body,labels,state --template '{{.title}}\n\n{{.body}}'`,
+			View:      `gh issue view "$IssueID" --json number,title,body,labels,state,url`,
 			Close:     `gh issue close "$IssueID"`,
 			SetStatus: `gh issue edit "$IssueID" --add-label "$Status"`,
 			Comment:   `gh issue comment "$IssueID" --body "$Body"`,
 		},
 		PR: &WorkflowPRConfig{
 			Create: `gh pr create --title "$Title" --body "$Description"`,
-			Merge:  `gh pr merge "$PRURL" --merge`,
+			Merge:  `gh pr merge "$PRNumber" --merge`,
 		},
 	}
 }

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -18,6 +18,7 @@ type FlowState struct {
 	Phase       string    `json:"phase"`
 	IssueID     string    `json:"issue_id,omitempty"`
 	PRURL       string    `json:"pr_url,omitempty"`
+	PRNumber    string    `json:"pr_number,omitempty"`
 	AutoMode    bool      `json:"auto_mode"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`

--- a/internal/workflow/taskfile.go
+++ b/internal/workflow/taskfile.go
@@ -1,0 +1,127 @@
+package workflow
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// TaskFile is the structured representation of a .cbox-task file.
+type TaskFile struct {
+	Task  TaskInfo   `yaml:"task"`
+	Issue *IssueInfo `yaml:"issue,omitempty"`
+	PR    *PRInfo    `yaml:"pr,omitempty"`
+}
+
+// TaskInfo holds the top-level task description.
+type TaskInfo struct {
+	Title       string `yaml:"title"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// IssueInfo holds structured issue data.
+type IssueInfo struct {
+	ID     string   `yaml:"id"`
+	Title  string   `yaml:"title,omitempty"`
+	Body   string   `yaml:"body,omitempty"`
+	State  string   `yaml:"state,omitempty"`
+	Labels []string `yaml:"labels,omitempty"`
+	URL    string   `yaml:"url,omitempty"`
+}
+
+// PRInfo holds pull request metadata.
+type PRInfo struct {
+	Number string `yaml:"number"`
+	URL    string `yaml:"url,omitempty"`
+	State  string `yaml:"state,omitempty"`
+}
+
+const taskFileName = ".cbox-task"
+
+// writeStructuredTaskFile marshals a TaskFile to YAML and writes it to the worktree.
+func writeStructuredTaskFile(worktreePath string, tf *TaskFile) error {
+	data, err := yaml.Marshal(tf)
+	if err != nil {
+		return fmt.Errorf("marshaling task file: %w", err)
+	}
+
+	content := "# This file is managed by cbox. Do not edit manually.\n" + string(data)
+	path := filepath.Join(worktreePath, taskFileName)
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// loadTaskFile reads and parses a .cbox-task YAML file from the worktree.
+func loadTaskFile(worktreePath string) (*TaskFile, error) {
+	path := filepath.Join(worktreePath, taskFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading task file: %w", err)
+	}
+
+	var tf TaskFile
+	if err := yaml.Unmarshal(data, &tf); err != nil {
+		return nil, fmt.Errorf("parsing task file: %w", err)
+	}
+	return &tf, nil
+}
+
+// parseIssueJSON parses the JSON output from `gh issue view --json`.
+func parseIssueJSON(jsonStr string) (*IssueInfo, error) {
+	var raw struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Body   string `json:"body"`
+		State  string `json:"state"`
+		URL    string `json:"url"`
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return nil, fmt.Errorf("parsing issue JSON: %w", err)
+	}
+
+	info := &IssueInfo{
+		ID:    fmt.Sprintf("%d", raw.Number),
+		Title: raw.Title,
+		Body:  raw.Body,
+		State: raw.State,
+		URL:   raw.URL,
+	}
+
+	for _, l := range raw.Labels {
+		info.Labels = append(info.Labels, l.Name)
+	}
+
+	return info, nil
+}
+
+// parsePROutput extracts PR URL and number from a `gh pr create` URL.
+// The URL is expected to be like https://github.com/owner/repo/pull/123.
+func parsePROutput(output string) (url, number string, err error) {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return "", "", fmt.Errorf("empty PR output")
+	}
+
+	// Find a URL in the output
+	re := regexp.MustCompile(`https://github\.com/[^\s]+/pull/(\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if matches == nil {
+		// Fall back: treat the whole output as a URL and try to extract a trailing number
+		reFallback := regexp.MustCompile(`/(\d+)\s*$`)
+		fb := reFallback.FindStringSubmatch(output)
+		if fb != nil {
+			return output, fb[1], nil
+		}
+		return output, "", fmt.Errorf("could not extract PR number from: %s", output)
+	}
+
+	return matches[0], matches[1], nil
+}

--- a/internal/workflow/taskfile_test.go
+++ b/internal/workflow/taskfile_test.go
@@ -1,0 +1,226 @@
+package workflow
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseIssueJSON(t *testing.T) {
+	input := `{
+		"number": 24,
+		"title": "Add structured task file",
+		"body": "We need to restructure .cbox-task to YAML.",
+		"state": "OPEN",
+		"url": "https://github.com/owner/repo/issues/24",
+		"labels": [
+			{"name": "enhancement"},
+			{"name": "workflow"}
+		]
+	}`
+
+	info, err := parseIssueJSON(input)
+	if err != nil {
+		t.Fatalf("parseIssueJSON failed: %v", err)
+	}
+
+	if info.ID != "24" {
+		t.Errorf("ID = %q, want %q", info.ID, "24")
+	}
+	if info.Title != "Add structured task file" {
+		t.Errorf("Title = %q, want %q", info.Title, "Add structured task file")
+	}
+	if info.Body != "We need to restructure .cbox-task to YAML." {
+		t.Errorf("Body = %q, want %q", info.Body, "We need to restructure .cbox-task to YAML.")
+	}
+	if info.State != "OPEN" {
+		t.Errorf("State = %q, want %q", info.State, "OPEN")
+	}
+	if info.URL != "https://github.com/owner/repo/issues/24" {
+		t.Errorf("URL = %q, want %q", info.URL, "https://github.com/owner/repo/issues/24")
+	}
+	if len(info.Labels) != 2 || info.Labels[0] != "enhancement" || info.Labels[1] != "workflow" {
+		t.Errorf("Labels = %v, want [enhancement workflow]", info.Labels)
+	}
+}
+
+func TestParseIssueJSON_NoLabels(t *testing.T) {
+	input := `{"number": 1, "title": "Test", "body": "", "state": "OPEN", "url": "", "labels": []}`
+
+	info, err := parseIssueJSON(input)
+	if err != nil {
+		t.Fatalf("parseIssueJSON failed: %v", err)
+	}
+
+	if info.ID != "1" {
+		t.Errorf("ID = %q, want %q", info.ID, "1")
+	}
+	if info.Labels != nil {
+		t.Errorf("Labels = %v, want nil", info.Labels)
+	}
+}
+
+func TestParseIssueJSON_InvalidJSON(t *testing.T) {
+	_, err := parseIssueJSON("not json")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestParsePROutput(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantURL    string
+		wantNumber string
+		wantErr    bool
+	}{
+		{
+			name:       "standard github URL",
+			input:      "https://github.com/owner/repo/pull/42",
+			wantURL:    "https://github.com/owner/repo/pull/42",
+			wantNumber: "42",
+		},
+		{
+			name:       "URL with trailing newline",
+			input:      "https://github.com/owner/repo/pull/7\n",
+			wantURL:    "https://github.com/owner/repo/pull/7",
+			wantNumber: "7",
+		},
+		{
+			name:       "URL with extra output before",
+			input:      "some warning text\nhttps://github.com/owner/repo/pull/123",
+			wantURL:    "https://github.com/owner/repo/pull/123",
+			wantNumber: "123",
+		},
+		{
+			name:    "empty input",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "no URL",
+			input:   "something without a number",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, number, err := parsePROutput(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if url != tt.wantURL {
+				t.Errorf("url = %q, want %q", url, tt.wantURL)
+			}
+			if number != tt.wantNumber {
+				t.Errorf("number = %q, want %q", number, tt.wantNumber)
+			}
+		})
+	}
+}
+
+func TestWriteAndLoadTaskFile(t *testing.T) {
+	dir := t.TempDir()
+
+	tf := &TaskFile{
+		Task: TaskInfo{
+			Title:       "Fix the bug",
+			Description: "It crashes on startup",
+		},
+		Issue: &IssueInfo{
+			ID:     "42",
+			Title:  "Fix the bug",
+			Body:   "It crashes on startup",
+			State:  "OPEN",
+			Labels: []string{"bug", "critical"},
+			URL:    "https://github.com/owner/repo/issues/42",
+		},
+		PR: &PRInfo{
+			Number: "7",
+			URL:    "https://github.com/owner/repo/pull/7",
+		},
+	}
+
+	if err := writeStructuredTaskFile(dir, tf); err != nil {
+		t.Fatalf("writeStructuredTaskFile failed: %v", err)
+	}
+
+	// Verify file exists
+	path := filepath.Join(dir, taskFileName)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading task file: %v", err)
+	}
+	content := string(data)
+
+	// Check header comment
+	if content[:1] != "#" {
+		t.Error("expected file to start with comment header")
+	}
+
+	// Round-trip
+	loaded, err := loadTaskFile(dir)
+	if err != nil {
+		t.Fatalf("loadTaskFile failed: %v", err)
+	}
+
+	if loaded.Task.Title != tf.Task.Title {
+		t.Errorf("Task.Title = %q, want %q", loaded.Task.Title, tf.Task.Title)
+	}
+	if loaded.Task.Description != tf.Task.Description {
+		t.Errorf("Task.Description = %q, want %q", loaded.Task.Description, tf.Task.Description)
+	}
+	if loaded.Issue == nil {
+		t.Fatal("Issue is nil")
+	}
+	if loaded.Issue.ID != "42" {
+		t.Errorf("Issue.ID = %q, want %q", loaded.Issue.ID, "42")
+	}
+	if len(loaded.Issue.Labels) != 2 {
+		t.Errorf("Issue.Labels = %v, want 2 labels", loaded.Issue.Labels)
+	}
+	if loaded.PR == nil {
+		t.Fatal("PR is nil")
+	}
+	if loaded.PR.Number != "7" {
+		t.Errorf("PR.Number = %q, want %q", loaded.PR.Number, "7")
+	}
+}
+
+func TestWriteTaskFile_NoPR(t *testing.T) {
+	dir := t.TempDir()
+
+	tf := &TaskFile{
+		Task: TaskInfo{
+			Title: "Simple task",
+		},
+		Issue: &IssueInfo{
+			ID:    "10",
+			Title: "Simple task",
+		},
+	}
+
+	if err := writeStructuredTaskFile(dir, tf); err != nil {
+		t.Fatalf("writeStructuredTaskFile failed: %v", err)
+	}
+
+	loaded, err := loadTaskFile(dir)
+	if err != nil {
+		t.Fatalf("loadTaskFile failed: %v", err)
+	}
+
+	if loaded.PR != nil {
+		t.Error("expected PR to be nil")
+	}
+	if loaded.Issue == nil || loaded.Issue.ID != "10" {
+		t.Error("expected Issue.ID to be 10")
+	}
+}

--- a/internal/workflow/template.go
+++ b/internal/workflow/template.go
@@ -95,11 +95,16 @@ func runShellCommandInDir(tmpl string, data any, dir string) (string, error) {
 		}
 	}
 
-	out, err := cmd.CombinedOutput()
-	output := strings.TrimSpace(string(out))
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err = cmd.Run()
+	output := strings.TrimSpace(stdout.String())
 
 	if err != nil {
-		return output, fmt.Errorf("command %q failed: %s: %w", rendered, output, err)
+		// Include both stdout and stderr in the error message for debugging
+		combined := strings.TrimSpace(stdout.String() + "\n" + stderr.String())
+		return output, fmt.Errorf("command %q failed: %s: %w", rendered, combined, err)
 	}
 
 	return output, nil


### PR DESCRIPTION
## Summary
- Replace plain-text `.cbox-task` with structured YAML containing task, issue, and PR sections
- Parse `gh issue view` JSON output into typed structs (`IssueInfo`) for richer context
- Extract PR number from `gh pr create` URL for robust merging (fixes fragile `$PRURL` usage)
- Add `PRNumber` field to `FlowState` for reliable PR identification
- Fall back gracefully for custom non-JSON view commands and old state files without `PRNumber`

## Test plan
- [x] `go build` compiles
- [x] `go test ./...` passes (new tests for parseIssueJSON, parsePROutput, write/load round-trip)
- [ ] Manual: verify `.cbox-task` written by flow start is valid YAML with expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)