### PR TITLE
Resume last conversation in cbox session

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -205,7 +205,7 @@ func chatCmd() *cobra.Command {
 			if prompt != "" {
 				return sandbox.ChatPrompt(dir, branch, prompt)
 			}
-			return sandbox.Chat(dir, branch, chrome, "")
+			return sandbox.Chat(dir, branch, chrome, "", false)
 		},
 	}
 

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -107,8 +107,9 @@ func Shell(name string) error {
 }
 
 // Chat execs into the Claude container and launches Claude Code interactively.
-// If initialPrompt is provided, it is sent as the first message in the conversation.
-func Chat(name string, chrome bool, initialPrompt string) error {
+// If resume is true, passes --continue to resume the last conversation.
+// Otherwise, if initialPrompt is provided, it is sent as the first message.
+func Chat(name string, chrome bool, initialPrompt string, resume bool) error {
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
 		return fmt.Errorf("docker not found: %w", err)
@@ -118,7 +119,9 @@ func Chat(name string, chrome bool, initialPrompt string) error {
 	if chrome {
 		args = append(args, "--chrome")
 	}
-	if initialPrompt != "" {
+	if resume {
+		args = append(args, "--continue")
+	} else if initialPrompt != "" {
 		args = append(args, initialPrompt)
 	}
 	return syscall.Exec(dockerPath, args, os.Environ())

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -186,14 +186,15 @@ func Down(projectDir, branch string) error {
 }
 
 // Chat launches Claude Code interactively in the Claude container.
-// If initialPrompt is provided, it is sent as the first message in the conversation.
-func Chat(projectDir, branch string, chrome bool, initialPrompt string) error {
+// If resume is true, passes --continue to resume the last conversation.
+// Otherwise, if initialPrompt is provided, it is sent as the first message.
+func Chat(projectDir, branch string, chrome bool, initialPrompt string, resume bool) error {
 	state, err := LoadState(projectDir, branch)
 	if err != nil {
 		return err
 	}
 
-	return docker.Chat(state.ClaudeContainer, chrome, initialPrompt)
+	return docker.Chat(state.ClaudeContainer, chrome, initialPrompt, resume)
 }
 
 // ChatPrompt runs a one-shot Claude prompt in the Claude container.

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -20,6 +20,7 @@ type FlowState struct {
 	PRURL       string    `json:"pr_url,omitempty"`
 	PRNumber    string    `json:"pr_number,omitempty"`
 	AutoMode    bool      `json:"auto_mode"`
+	Chatted     bool      `json:"chatted"`
 	CreatedAt   time.Time `json:"created_at"`
 	UpdatedAt   time.Time `json:"updated_at"`
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -282,13 +282,26 @@ func FlowChat(projectDir, branch, openCmd string) error {
 		chrome = true
 	}
 
-	initialPrompt := `Do these two things before anything else:
+	resume := state.Chatted
+
+	if !state.Chatted {
+		state.Chatted = true
+		if err := SaveFlowState(projectDir, state); err != nil {
+			return fmt.Errorf("saving flow state: %w", err)
+		}
+	}
+
+	var initialPrompt string
+	if !resume {
+		initialPrompt = `Do these two things before anything else:
 
 1. Read /workspace/.cbox-task and summarize the task.
 2. Check your environment: what runtimes, tools, and commands are available? Try running the project's build and test commands via your MCP tools. If anything is missing or broken, warn me clearly about what's not working and what needs to be fixed before we can start.
 
 After reporting both, wait for my instructions.`
-	return sandbox.Chat(projectDir, branch, chrome, initialPrompt)
+	}
+
+	return sandbox.Chat(projectDir, branch, chrome, initialPrompt, resume)
 }
 
 // FlowPR creates a pull request for the flow.


### PR DESCRIPTION
## Summary

Implemented conversation resumption for `cbox flow chat` using Claude Code's `--continue` flag.

## Changes

**5 files changed across 4 packages:**

1. **`internal/workflow/state.go`** — Added `Chatted bool` field to `FlowState` struct. Backward-compatible: existing JSON files without `"chatted"` unmarshal as `false`.

2. **`internal/docker/container.go`** — Added `resume bool` parameter to `Chat()`. When `resume` is true, passes `--continue` to Claude Code. Mutually exclusive with `initialPrompt`.

3. **`internal/sandbox/sandbox.go`** — Updated `Chat()` signature to pass `resume` through to `docker.Chat()`.

4. **`internal/workflow/workflow.go`** — Added resume logic in `FlowChat()`: reads `state.Chatted`, sets it to `true` and persists before `syscall.Exec` on first chat. Subsequent chats pass `--continue` instead of the initial prompt.

5. **`cmd/cbox/main.go`** — Updated standalone `chatCmd()` to pass `false` for the new `resume` parameter (standalone chat always starts fresh).

## Verification

- `cbox_build` — compiles successfully
- `cbox_test` — all tests pass

## Edge cases handled

- **Existing flow states**: Missing `"chatted"` key unmarshals as `false` — first chat after upgrade works correctly
- **Container recreated**: `Chatted` remains `true` but Claude Code handles `--continue` gracefully when no prior session exists
- **Flow cleanup** (abandon/merge): Deletes `FlowState` entirely, so `Chatted` resets naturally