### PR TITLE
Override open flag to skip default open command

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -448,17 +448,21 @@ func flowInitCmd() *cobra.Command {
 
 func flowStartCmd() *cobra.Command {
 	var yolo bool
+	var openCmd string
 
 	cmd := &cobra.Command{
 		Use:   "start <description>",
 		Short: "Begin a new workflow: create issue and sandbox",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return workflow.FlowStart(projectDir(), args[0], yolo)
+			openFlag := cmd.Flags().Changed("open")
+			return workflow.FlowStart(projectDir(), args[0], yolo, openFlag, openCmd)
 		},
 	}
 
 	cmd.Flags().BoolVar(&yolo, "yolo", false, "Run all phases automatically (research, execute, PR)")
+	cmd.Flags().StringVar(&openCmd, "open", "", "Run a command before chat (use $Dir for worktree path); omit value to use config default")
+	cmd.Flags().Lookup("open").NoOptDefVal = " "
 	return cmd
 }
 
@@ -486,11 +490,13 @@ func flowChatCmd() *cobra.Command {
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: branchCompletion(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return workflow.FlowChat(projectDir(), args[0], openCmd)
+			openFlag := cmd.Flags().Changed("open")
+			return workflow.FlowChat(projectDir(), args[0], openFlag, openCmd)
 		},
 	}
 
-	cmd.Flags().StringVar(&openCmd, "open", "", "Run a command before chat (use $Dir for worktree path)")
+	cmd.Flags().StringVar(&openCmd, "open", "", "Run a command before chat (use $Dir for worktree path); omit value to use config default")
+	cmd.Flags().Lookup("open").NoOptDefVal = " "
 	return cmd
 }
 

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -1,0 +1,73 @@
+package workflow
+
+import "testing"
+
+func TestResolveOpenCommand(t *testing.T) {
+	tests := []struct {
+		name       string
+		openFlag   bool
+		openCmd    string
+		configOpen string
+		want       string
+	}{
+		{
+			name:       "flag not set, no config",
+			openFlag:   false,
+			openCmd:    "",
+			configOpen: "",
+			want:       "",
+		},
+		{
+			name:       "flag not set, config present",
+			openFlag:   false,
+			openCmd:    "",
+			configOpen: "code $Dir",
+			want:       "",
+		},
+		{
+			name:       "flag set with command",
+			openFlag:   true,
+			openCmd:    "vim $Dir",
+			configOpen: "code $Dir",
+			want:       "vim $Dir",
+		},
+		{
+			name:       "flag set without value, config present",
+			openFlag:   true,
+			openCmd:    "",
+			configOpen: "code $Dir",
+			want:       "code $Dir",
+		},
+		{
+			name:       "flag set with whitespace-only value, config present",
+			openFlag:   true,
+			openCmd:    " ",
+			configOpen: "code $Dir",
+			want:       "code $Dir",
+		},
+		{
+			name:       "flag set without value, no config",
+			openFlag:   true,
+			openCmd:    "",
+			configOpen: "",
+			want:       "",
+		},
+		{
+			name:       "flag set with command, no config",
+			openFlag:   true,
+			openCmd:    "vim $Dir",
+			configOpen: "",
+			want:       "vim $Dir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveOpenCommand(tt.openFlag, tt.openCmd, tt.configOpen)
+			if got != tt.want {
+				t.Errorf("resolveOpenCommand(%v, %q, %q) = %q, want %q",
+					tt.openFlag, tt.openCmd, tt.configOpen, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The `--open` flag for `cbox flow start` and `cbox flow chat` is now opt-in. Previously, the open command would always run if configured in `.cbox.toml` (via the `open` key), even when the user didn't pass `--open`. Now the open logic only triggers when `--open` is explicitly provided on the command line.

## Behavior

| Command | Behavior |
|---------|----------|
| `cbox flow start "task"` | No open command runs |
| `cbox flow start --open "task"` | Uses `cfg.Open` from `.cbox.toml` |
| `cbox flow start --open="vim $Dir" "task"` | Uses `vim $Dir` as the open command |
| `cbox flow chat branch` | No open command runs |
| `cbox flow chat --open branch` | Uses `cfg.Open` from `.cbox.toml` |
| `cbox flow chat --open="vim $Dir" branch` | Uses `vim $Dir` as the open command |

## Changes

### `cmd/cbox/main.go`
- **`flowStartCmd()`**: Added `--open` flag (was previously missing). Uses `cmd.Flags().Changed("open")` to detect explicit usage. Sets `NoOptDefVal` to allow `--open` without a value.
- **`flowChatCmd()`**: Same changes — uses `Changed("open")` and `NoOptDefVal`.

### `internal/workflow/workflow.go`
- **`resolveOpenCommand()`**: New exported helper that encapsulates the open command resolution logic. Returns empty string when flag not set, falls back to config when flag set without value.
- **`FlowStart()`**: Added `openFlag bool` and `openCmd string` parameters. Runs the resolved open command after sandbox is ready.
- **`FlowChat()`**: Changed `openCmd string` parameter to `openFlag bool, openCmd string`. Replaced inline open logic with `resolveOpenCommand()`.

### `internal/workflow/workflow_test.go` (new)
- 7 test cases covering all combinations: flag not set, flag set with/without value, with/without config default.