### PR TITLE
Add support for copying files to new git worktrees

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	EnvFile      string            `toml:"env_file,omitempty"`
 	Browser      bool              `toml:"browser,omitempty"`
 	HostCommands []string          `toml:"host_commands,omitempty"`
+	CopyFiles    []string          `toml:"copy_files,omitempty"`
 	Dockerfile   string            `toml:"dockerfile,omitempty"`
 	Open         string            `toml:"open,omitempty"`
 	Editor       string            `toml:"editor,omitempty"`
@@ -56,6 +57,7 @@ func DefaultConfig() *Config {
 		},
 		Env:          []string{"ANTHROPIC_API_KEY"},
 		HostCommands: []string{"git", "gh"},
+		CopyFiles:    []string{".env"},
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,59 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig_CopyFilesIncludesEnv(t *testing.T) {
+	cfg := DefaultConfig()
+	if len(cfg.CopyFiles) != 1 || cfg.CopyFiles[0] != ".env" {
+		t.Errorf("DefaultConfig().CopyFiles = %v, want [\".env\"]", cfg.CopyFiles)
+	}
+}
+
+func TestLoadConfig_ParsesCopyFiles(t *testing.T) {
+	dir := t.TempDir()
+	content := `copy_files = [".env", ".env.local", "config/secrets"]` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	want := []string{".env", ".env.local", "config/secrets"}
+	if len(cfg.CopyFiles) != len(want) {
+		t.Fatalf("CopyFiles length = %d, want %d", len(cfg.CopyFiles), len(want))
+	}
+	for i, v := range want {
+		if cfg.CopyFiles[i] != v {
+			t.Errorf("CopyFiles[%d] = %q, want %q", i, cfg.CopyFiles[i], v)
+		}
+	}
+}
+
+func TestSaveAndLoad_RoundTripCopyFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := DefaultConfig()
+	cfg.CopyFiles = []string{".env", "data/fixtures"}
+	if err := cfg.Save(dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if len(loaded.CopyFiles) != 2 {
+		t.Fatalf("CopyFiles length = %d, want 2", len(loaded.CopyFiles))
+	}
+	if loaded.CopyFiles[0] != ".env" || loaded.CopyFiles[1] != "data/fixtures" {
+		t.Errorf("CopyFiles = %v, want [\".env\", \"data/fixtures\"]", loaded.CopyFiles)
+	}
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -45,6 +45,14 @@ func UpWithOptions(projectDir, branch string, opts UpOptions) error {
 	}
 	fmt.Printf("Worktree ready at %s\n", wtPath)
 
+	// Copy configured files into the new worktree
+	if len(cfg.CopyFiles) > 0 {
+		fmt.Println("Copying files to worktree...")
+		if err := worktree.CopyFiles(projectDir, wtPath, cfg.CopyFiles); err != nil {
+			return fmt.Errorf("copying files to worktree: %w", err)
+		}
+	}
+
 	// 2. Build Claude image
 	claudeImage := docker.ImageName(projectName, "claude")
 	fmt.Printf("Building Claude image %s...\n", claudeImage)

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -1,0 +1,174 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCopyFiles_SingleFile(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a source file.
+	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("SECRET=abc"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFiles(src, dst, []string{".env"}); err != nil {
+		t.Fatalf("CopyFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, ".env"))
+	if err != nil {
+		t.Fatalf("reading copied file: %v", err)
+	}
+	if string(got) != "SECRET=abc" {
+		t.Errorf("got %q, want %q", string(got), "SECRET=abc")
+	}
+}
+
+func TestCopyFiles_Directory(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a source directory with nested files.
+	dir := filepath.Join(src, "config", "sub")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "config", "a.txt"), []byte("aaa"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("bbb"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFiles(src, dst, []string{"config"}); err != nil {
+		t.Fatalf("CopyFiles: %v", err)
+	}
+
+	// Verify both files were copied.
+	gotA, err := os.ReadFile(filepath.Join(dst, "config", "a.txt"))
+	if err != nil {
+		t.Fatalf("reading config/a.txt: %v", err)
+	}
+	if string(gotA) != "aaa" {
+		t.Errorf("config/a.txt: got %q, want %q", string(gotA), "aaa")
+	}
+
+	gotB, err := os.ReadFile(filepath.Join(dst, "config", "sub", "b.txt"))
+	if err != nil {
+		t.Fatalf("reading config/sub/b.txt: %v", err)
+	}
+	if string(gotB) != "bbb" {
+		t.Errorf("config/sub/b.txt: got %q, want %q", string(gotB), "bbb")
+	}
+}
+
+func TestCopyFiles_MissingSourceSkipped(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// No source file exists — should not error.
+	if err := CopyFiles(src, dst, []string{".env", "missing.txt"}); err != nil {
+		t.Fatalf("CopyFiles should skip missing files, got: %v", err)
+	}
+
+	// Nothing should have been created.
+	entries, _ := os.ReadDir(dst)
+	if len(entries) != 0 {
+		t.Errorf("expected empty destination, got %d entries", len(entries))
+	}
+}
+
+func TestCopyFiles_PreservesPermissions(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	srcPath := filepath.Join(src, "script.sh")
+	if err := os.WriteFile(srcPath, []byte("#!/bin/sh"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFiles(src, dst, []string{"script.sh"}); err != nil {
+		t.Fatalf("CopyFiles: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dst, "script.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("permissions: got %o, want %o", info.Mode().Perm(), 0755)
+	}
+}
+
+func TestCopyFiles_NestedFilePath(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	// Create a file in a subdirectory.
+	if err := os.MkdirAll(filepath.Join(src, "deep"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "deep", "secret.key"), []byte("key123"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFiles(src, dst, []string{"deep/secret.key"}); err != nil {
+		t.Fatalf("CopyFiles: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "deep", "secret.key"))
+	if err != nil {
+		t.Fatalf("reading copied file: %v", err)
+	}
+	if string(got) != "key123" {
+		t.Errorf("got %q, want %q", string(got), "key123")
+	}
+}
+
+func TestCopyFiles_MultiplePatterns(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(src, ".env"), []byte("A=1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, ".env.local"), []byte("B=2"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := CopyFiles(src, dst, []string{".env", ".env.local"}); err != nil {
+		t.Fatalf("CopyFiles: %v", err)
+	}
+
+	got1, err := os.ReadFile(filepath.Join(dst, ".env"))
+	if err != nil {
+		t.Fatalf("reading .env: %v", err)
+	}
+	if string(got1) != "A=1" {
+		t.Errorf(".env: got %q, want %q", string(got1), "A=1")
+	}
+
+	got2, err := os.ReadFile(filepath.Join(dst, ".env.local"))
+	if err != nil {
+		t.Fatalf("reading .env.local: %v", err)
+	}
+	if string(got2) != "B=2" {
+		t.Errorf(".env.local: got %q, want %q", string(got2), "B=2")
+	}
+}
+
+func TestCopyFiles_EmptyList(t *testing.T) {
+	src := t.TempDir()
+	dst := t.TempDir()
+
+	if err := CopyFiles(src, dst, nil); err != nil {
+		t.Fatalf("CopyFiles with nil: %v", err)
+	}
+	if err := CopyFiles(src, dst, []string{}); err != nil {
+		t.Fatalf("CopyFiles with empty: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Added a `copy_files` array field to `.cbox.toml` that copies specified files or directories from the project root into newly created git worktrees. The primary use case is `.env` files that aren't tracked in git but are needed in each worktree.

## Changes

### `internal/config/config.go`
- Added `CopyFiles []string` field to the `Config` struct with TOML tag `copy_files`
- Added `CopyFiles: []string{".env"}` to `DefaultConfig()` so new projects get `.env` copying by default

### `internal/worktree/worktree.go`
- Added `CopyFiles(projectDir, wtPath string, patterns []string) error` — iterates over patterns, copies files or directories from project root to worktree. Missing sources are silently skipped.
- Added `copyFile(src, dst string) error` — copies a single file preserving permissions
- Added `copyDir(src, dst string) error` — recursively copies a directory tree

### `internal/sandbox/sandbox.go`
- Integrated `worktree.CopyFiles()` into `UpWithOptions()` immediately after worktree creation (before Docker image build)

### Tests added
- `internal/config/config_test.go` — 3 tests: default config includes `.env`, TOML parsing of `copy_files`, save/load round-trip
- `internal/worktree/worktree_test.go` — 7 tests: single file copy, directory copy, missing source skip, permission preservation, nested file paths, multiple patterns, empty list

All tests pass. Build succeeds.