### PR TITLE
Track PR merge status in cbox flow status command

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type WorkflowIssueConfig struct {
 type WorkflowPRConfig struct {
 	Create string `toml:"create,omitempty"`
 	Merge  string `toml:"merge,omitempty"`
+	View   string `toml:"view,omitempty"`
 }
 
 type WorkflowPromptConfig struct {
@@ -74,6 +75,7 @@ func DefaultWorkflowConfig() *WorkflowConfig {
 		PR: &WorkflowPRConfig{
 			Create: `gh pr create --title "$Title" --body "$Description"`,
 			Merge:  `gh pr merge "$PRNumber" --merge`,
+			View:   `gh pr view "$PRNumber" --json number,state,title,url,mergedAt`,
 		},
 	}
 }

--- a/internal/workflow/taskfile.go
+++ b/internal/workflow/taskfile.go
@@ -102,6 +102,38 @@ func parseIssueJSON(jsonStr string) (*IssueInfo, error) {
 	return info, nil
 }
 
+// PRStatus holds the state of a pull request fetched from the provider.
+type PRStatus struct {
+	Number   string
+	State    string // e.g. "OPEN", "CLOSED", "MERGED"
+	Title    string
+	URL      string
+	MergedAt string
+}
+
+// parsePRJSON parses the JSON output from `gh pr view --json`.
+func parsePRJSON(jsonStr string) (*PRStatus, error) {
+	var raw struct {
+		Number   int    `json:"number"`
+		State    string `json:"state"`
+		Title    string `json:"title"`
+		URL      string `json:"url"`
+		MergedAt string `json:"mergedAt"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
+		return nil, fmt.Errorf("parsing PR JSON: %w", err)
+	}
+
+	return &PRStatus{
+		Number:   fmt.Sprintf("%d", raw.Number),
+		State:    raw.State,
+		Title:    raw.Title,
+		URL:      raw.URL,
+		MergedAt: raw.MergedAt,
+	}, nil
+}
+
 // parsePROutput extracts PR URL and number from a `gh pr create` URL.
 // The URL is expected to be like https://github.com/owner/repo/pull/123.
 func parsePROutput(output string) (url, number string, err error) {

--- a/internal/workflow/taskfile_test.go
+++ b/internal/workflow/taskfile_test.go
@@ -67,6 +67,60 @@ func TestParseIssueJSON_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestParsePRJSON(t *testing.T) {
+	input := `{
+		"number": 42,
+		"state": "MERGED",
+		"title": "Add feature X",
+		"url": "https://github.com/owner/repo/pull/42",
+		"mergedAt": "2025-01-15T10:30:00Z"
+	}`
+
+	status, err := parsePRJSON(input)
+	if err != nil {
+		t.Fatalf("parsePRJSON failed: %v", err)
+	}
+
+	if status.Number != "42" {
+		t.Errorf("Number = %q, want %q", status.Number, "42")
+	}
+	if status.State != "MERGED" {
+		t.Errorf("State = %q, want %q", status.State, "MERGED")
+	}
+	if status.Title != "Add feature X" {
+		t.Errorf("Title = %q, want %q", status.Title, "Add feature X")
+	}
+	if status.URL != "https://github.com/owner/repo/pull/42" {
+		t.Errorf("URL = %q, want %q", status.URL, "https://github.com/owner/repo/pull/42")
+	}
+	if status.MergedAt != "2025-01-15T10:30:00Z" {
+		t.Errorf("MergedAt = %q, want %q", status.MergedAt, "2025-01-15T10:30:00Z")
+	}
+}
+
+func TestParsePRJSON_Open(t *testing.T) {
+	input := `{"number": 7, "state": "OPEN", "title": "WIP", "url": "https://github.com/owner/repo/pull/7", "mergedAt": ""}`
+
+	status, err := parsePRJSON(input)
+	if err != nil {
+		t.Fatalf("parsePRJSON failed: %v", err)
+	}
+
+	if status.State != "OPEN" {
+		t.Errorf("State = %q, want %q", status.State, "OPEN")
+	}
+	if status.MergedAt != "" {
+		t.Errorf("MergedAt = %q, want empty", status.MergedAt)
+	}
+}
+
+func TestParsePRJSON_InvalidJSON(t *testing.T) {
+	_, err := parsePRJSON("not json")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
 func TestParsePROutput(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -1,6 +1,69 @@
 package workflow
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/richvanbergen/cbox/internal/config"
+)
+
+func TestFormatPRPhase(t *testing.T) {
+	tests := []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{"merged", "MERGED", "merged"},
+		{"open", "OPEN", "pr-open"},
+		{"closed", "CLOSED", "pr-closed"},
+		{"lowercase merged", "merged", "merged"},
+		{"unknown state", "DRAFT", "draft"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := &PRStatus{State: tt.state}
+			got := formatPRPhase(status)
+			if got != tt.want {
+				t.Errorf("formatPRPhase(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchPRStatus_NoPRNumber(t *testing.T) {
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{
+			View: `echo '{"number":1,"state":"OPEN","title":"t","url":"u","mergedAt":""}'`,
+		},
+	}
+	state := &FlowState{PRNumber: ""}
+
+	status := fetchPRStatus(wf, state)
+	if status != nil {
+		t.Error("expected nil when PRNumber is empty")
+	}
+}
+
+func TestFetchPRStatus_NilWorkflow(t *testing.T) {
+	state := &FlowState{PRNumber: "42"}
+
+	status := fetchPRStatus(nil, state)
+	if status != nil {
+		t.Error("expected nil when workflow config is nil")
+	}
+}
+
+func TestFetchPRStatus_NoViewCommand(t *testing.T) {
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{},
+	}
+	state := &FlowState{PRNumber: "42"}
+
+	status := fetchPRStatus(wf, state)
+	if status != nil {
+		t.Error("expected nil when view command is empty")
+	}
+}
 
 func TestResolveOpenCommand(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Implemented live PR status fetching in `cbox flow status` so that when a PR has been created, the command queries the provider (e.g. GitHub) for the current PR state and displays it.

## Changes

### `internal/config/config.go`
- Added `View` field to `WorkflowPRConfig` for configuring the PR view command
- Added default view command: `gh pr view "$PRNumber" --json number,state,title,url,mergedAt`

### `internal/workflow/taskfile.go`
- Added `PRStatus` struct to hold parsed PR state (Number, State, Title, URL, MergedAt)
- Added `parsePRJSON()` function to parse JSON output from `gh pr view --json`

### `internal/workflow/workflow.go`
- Added `fetchPRStatus()` function that runs the configured PR view command and returns the live status
- Added `formatPRPhase()` function that maps PR states to display strings: "merged", "pr-open", "pr-closed"
- Updated `FlowStatus()` to load config and pass workflow config through
- Updated flow list view to show live PR phase instead of local phase when a PR exists
- Updated `printFlowState()` to show a "PR status:" line with the live status

### Test files
- `taskfile_test.go`: Added tests for `parsePRJSON` (merged, open, invalid JSON)
- `workflow_test.go`: Added tests for `formatPRPhase` (all states) and `fetchPRStatus` edge cases (no PR number, nil workflow, no view command)

## Behavior

- **Flow list (`cbox flow status`)**: When a flow has a PR, the phase column shows the live PR state (e.g., "merged" instead of "started")
- **Single flow view (`cbox flow status <branch>`)**: Shows a "PR status:" line with the live state
- Gracefully falls back to local phase when no PR exists, no view command is configured, or the command fails