### PR TITLE
Add --open flag to cbox chat command

### DIFF
--- a/cmd/cbox/chat_test.go
+++ b/cmd/cbox/chat_test.go
@@ -1,0 +1,54 @@
+package main
+
+import "testing"
+
+func TestChatCmd_OpenFlagNoOptDefVal(t *testing.T) {
+	cmd := chatCmd()
+	f := cmd.Flags().Lookup("open")
+	if f == nil {
+		t.Fatal("expected --open flag to be registered")
+	}
+	if f.NoOptDefVal != " " {
+		t.Errorf("NoOptDefVal = %q, want %q", f.NoOptDefVal, " ")
+	}
+}
+
+func TestChatCmd_OpenFlagNotChangedByDefault(t *testing.T) {
+	cmd := chatCmd()
+	// Simulate parsing with no --open flag.
+	if err := cmd.ParseFlags([]string{"mybranch"}); err != nil {
+		t.Fatal(err)
+	}
+	if cmd.Flags().Changed("open") {
+		t.Error("expected --open to not be changed when not provided")
+	}
+}
+
+func TestChatCmd_OpenFlagChangedWhenProvided(t *testing.T) {
+	cmd := chatCmd()
+	// Simulate parsing with --open flag (no value, uses NoOptDefVal).
+	if err := cmd.ParseFlags([]string{"--open", "mybranch"}); err != nil {
+		t.Fatal(err)
+	}
+	if !cmd.Flags().Changed("open") {
+		t.Error("expected --open to be changed when explicitly provided")
+	}
+}
+
+func TestChatCmd_OpenFlagChangedWithValue(t *testing.T) {
+	cmd := chatCmd()
+	// Simulate parsing with --open=command.
+	if err := cmd.ParseFlags([]string{"--open=vim $Dir", "mybranch"}); err != nil {
+		t.Fatal(err)
+	}
+	if !cmd.Flags().Changed("open") {
+		t.Error("expected --open to be changed when provided with value")
+	}
+	val, err := cmd.Flags().GetString("open")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val != "vim $Dir" {
+		t.Errorf("open flag value = %q, want %q", val, "vim $Dir")
+	}
+}


### PR DESCRIPTION
## Summary

The `cbox chat` command was unconditionally running the config's open command (`cfg.Open`) whenever a branch was specified, regardless of whether `--open` was passed. This has been fixed to match the `cbox flow chat` behavior.

## Changes

### `cmd/cbox/main.go`
- **`runOpenCommand`**: Added `openFlag bool` parameter. When `openFlag` is false, the function returns immediately without running any command. Also added `strings.TrimSpace` on the flag value to match `resolveOpenCommand` in the workflow package.
- **`chatCmd`**: Now checks `cmd.Flags().Changed("open")` to detect explicit flag usage, passes the boolean to `runOpenCommand`. Added `NoOptDefVal = " "` so `--open` can be used without a value (falls back to config default).

### `cmd/cbox/chat_test.go` (new)
- Tests that the `--open` flag has `NoOptDefVal` set correctly
- Tests that the flag is not marked as changed when not provided
- Tests that the flag is marked as changed when provided (both with and without a value)

## Behavior

| Command | Before | After |
|---------|--------|-------|
| `cbox chat branch` | Runs config open command | Does NOT run open command |
| `cbox chat branch --open` | Runs config open command | Runs config open command |
| `cbox chat branch --open="cmd"` | Runs "cmd" | Runs "cmd" |

All tests pass, build succeeds.