### PR TITLE
Improve terminal output framing and logging decorations

### DIFF
--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/richvanbergen/cbox/internal/output"
 )
 
 //go:embed templates/Dockerfile.claude.tmpl templates/entrypoint.sh
@@ -63,9 +65,12 @@ func BuildClaudeImage(imageName string, opts BuildOptions) error {
 	buildArgs = append(buildArgs, tmpDir)
 
 	cmd := exec.Command("docker", buildArgs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	cw := output.NewCommandWriter(os.Stdout)
+	cmd.Stdout = cw
+	cmd.Stderr = cw
+	err = cmd.Run()
+	cw.Close()
+	if err != nil {
 		return fmt.Errorf("building claude image: %w", err)
 	}
 	return nil

--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 
 	"github.com/richvanbergen/cbox/internal/bridge"
+	"github.com/richvanbergen/cbox/internal/output"
 )
 
 // ContainerName returns a deterministic container name with a role suffix.
@@ -87,10 +88,13 @@ func RunClaudeContainer(name, image, network, worktreePath string, envVars []str
 	args = append(args, image)
 
 	cmd := exec.Command("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker run (claude): %w", err)
+	cw := output.NewCommandWriter(os.Stdout)
+	cmd.Stdout = cw
+	cmd.Stderr = cw
+	runErr := cmd.Run()
+	cw.Close()
+	if runErr != nil {
+		return fmt.Errorf("docker run (claude): %w", runErr)
 	}
 	return nil
 }

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -82,7 +82,7 @@ func FlowStart(projectDir, description string, yolo bool, openFlag bool, openCmd
 	title := summarize(description)
 	var issueID string
 	if wf.Issue != nil && wf.Issue.Create != "" {
-		output.Progress("Creating issue...")
+		output.Progress("Creating issue")
 		issueID, err = runShellCommand(wf.Issue.Create, map[string]string{
 			"Title":       title,
 			"Description": description,
@@ -109,7 +109,7 @@ func FlowStart(projectDir, description string, yolo bool, openFlag bool, openCmd
 
 	// Start sandbox with report dir
 	repDir := reportDir(projectDir, branch)
-	output.Progress("Starting sandbox...")
+	output.Progress("Starting sandbox")
 	if err := sandbox.UpWithOptions(projectDir, branch, sandbox.UpOptions{
 		ReportDir:  repDir,
 		FlowBranch: branch,
@@ -132,7 +132,7 @@ func FlowStart(projectDir, description string, yolo bool, openFlag bool, openCmd
 	}
 
 	if issueID != "" && wf.Issue != nil && wf.Issue.View != "" {
-		output.Progress("Fetching issue content...")
+		output.Progress("Fetching issue content")
 		issueContent, err := runShellCommand(wf.Issue.View, map[string]string{
 			"IssueID": issueID,
 		})
@@ -220,12 +220,12 @@ Do NOT use gh or any tool to:
 		"TaskContent": taskContent,
 	})
 
-	output.Progress("Running in yolo mode...")
+	output.Progress("Running in yolo mode")
 	if err := sandbox.ChatPrompt(projectDir, branch, prompt); err != nil {
 		return fmt.Errorf("yolo execution failed: %w", err)
 	}
 
-	output.Progress("Creating PR...")
+	output.Progress("Creating PR")
 	return FlowPR(projectDir, branch)
 }
 
@@ -260,7 +260,7 @@ func FlowChat(projectDir, branch string, openFlag bool, openCmd string) error {
 	}
 
 	if state.IssueID != "" && wf != nil && wf.Issue != nil && wf.Issue.View != "" {
-		output.Progress("Refreshing task from issue...")
+		output.Progress("Refreshing task from issue")
 		issueContent, err := runShellCommand(wf.Issue.View, map[string]string{
 			"IssueID": state.IssueID,
 		})
@@ -374,14 +374,14 @@ func FlowPR(projectDir, branch string) error {
 	}
 
 	// Push the branch first
-	output.Progress("Pushing branch...")
+	output.Progress("Pushing branch")
 	if _, err := runShellCommandInDir("git push -u origin $Branch", map[string]string{
 		"Branch": branch,
 	}, wtPath); err != nil {
 		return fmt.Errorf("pushing branch: %w", err)
 	}
 
-	output.Progress("Creating PR...")
+	output.Progress("Creating PR")
 	prOutput, err := runShellCommandInDir(wf.PR.Create, map[string]string{
 		"Title":       state.Title,
 		"Description": description,
@@ -458,7 +458,7 @@ func FlowMerge(projectDir, branch string) error {
 			prNumber = extracted
 		}
 
-		output.Progress("Merging PR...")
+		output.Progress("Merging PR")
 		if _, err := runShellCommand(wf.PR.Merge, map[string]string{
 			"PRURL":    state.PRURL,
 			"PRNumber": prNumber,
@@ -485,7 +485,7 @@ func FlowMerge(projectDir, branch string) error {
 	}
 
 	// Clean up sandbox
-	output.Progress("Cleaning up sandbox...")
+	output.Progress("Cleaning up sandbox")
 	if err := sandbox.Clean(projectDir, branch); err != nil {
 		output.Warning("Sandbox cleanup failed: %v", err)
 	}
@@ -635,7 +635,7 @@ func FlowAbandon(projectDir, branch string) error {
 	}
 
 	// Clean up sandbox
-	output.Progress("Cleaning up sandbox...")
+	output.Progress("Cleaning up sandbox")
 	if err := sandbox.Clean(projectDir, branch); err != nil {
 		output.Warning("Sandbox cleanup failed: %v", err)
 	}


### PR DESCRIPTION
## Summary

Implemented cleaner, more readable terminal output with three changes:

### 1. Lighter progress prefix
Replaced heavy `...` prefix with `›` on all progress lines in `internal/output/render.go`.

### 2. Removed trailing ellipsis from all messages
Stripped trailing `...` from all `output.Progress()` format strings across:
- `internal/sandbox/sandbox.go` — 13 calls (Preparing worktree, Building image, Creating network, Starting/Stopping proxies and containers, Injecting config, Removing resources)
- `internal/workflow/workflow.go` — 10 calls (Creating issue, Starting sandbox, Fetching issue, Running yolo, Creating/Merging PR, Pushing branch, Cleaning up, Refreshing task)
- Converted stray `fmt.Println("Copying files to worktree...")` to `output.Progress("Copying files to worktree")`

### 3. Added `CommandWriter` for framing third-party output
New `CommandWriter` struct in `internal/output/render.go` that:
- Wraps an `io.Writer` and prepends a dim `│ ` border to each line
- Prints a blank line on first write for visual separation
- Buffers partial lines and flushes on `Close()`

Applied in:
- `internal/docker/build.go` — docker image build stdout/stderr
- `internal/docker/container.go` — docker run stdout/stderr

### 4. Updated tests
- Updated `TestRenderProgressBlock` and `TestConvenienceFunctions` to check for `›` instead of `...`
- Added `TestCommandWriter`, `TestCommandWriterPartialLines`, and `TestCommandWriterFlushOnClose`

### Verification
- `cbox_build` — compiles cleanly
- `cbox_test` — all tests pass across all packages