### PR TITLE
Open sandboxed environment without chat session

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -29,6 +29,7 @@ func main() {
 	root.AddCommand(upCmd())
 	root.AddCommand(downCmd())
 	root.AddCommand(chatCmd())
+	root.AddCommand(openCmd())
 	root.AddCommand(shellCmd())
 	root.AddCommand(listCmd())
 	root.AddCommand(infoCmd())
@@ -181,6 +182,37 @@ func runOpenCommand(cfg *config.Config, flagValue, projectDir, branch string) {
 	if err := c.Run(); err != nil {
 		output.Warning("Open command failed: %v", err)
 	}
+}
+
+func openCmd() *cobra.Command {
+	var openCmdFlag string
+
+	cmd := &cobra.Command{
+		Use:               "open <branch>",
+		Short:             "Run the open command for a sandbox (without starting a chat)",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: branchCompletion(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			dir := projectDir()
+			branch := args[0]
+
+			cfg, _ := config.Load(dir)
+
+			openExpr := openCmdFlag
+			if openExpr == "" && cfg != nil {
+				openExpr = cfg.Open
+			}
+			if openExpr == "" {
+				return fmt.Errorf("no open command configured — set open in %s or pass --open", config.ConfigFile)
+			}
+
+			runOpenCommand(cfg, openExpr, dir, branch)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&openCmdFlag, "open", "", "Command to run (overrides config; use $Dir for worktree path)")
+	return cmd
 }
 
 func chatCmd() *cobra.Command {

--- a/cmd/cbox/open_test.go
+++ b/cmd/cbox/open_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestOpenCmd_RequiresBranchArg(t *testing.T) {
+	cmd := openCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no branch arg provided")
+	}
+}
+
+func TestOpenCmd_RejectsExtraArgs(t *testing.T) {
+	cmd := openCmd()
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetArgs([]string{"branch1", "branch2"})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when extra args provided")
+	}
+}
+
+func TestOpenCmd_HasOpenFlag(t *testing.T) {
+	cmd := openCmd()
+	f := cmd.Flags().Lookup("open")
+	if f == nil {
+		t.Fatal("expected --open flag to be defined")
+	}
+	if f.DefValue != "" {
+		t.Errorf("expected --open default to be empty, got %q", f.DefValue)
+	}
+}


### PR DESCRIPTION
## Summary

Added a new `cbox open <branch>` command that runs the open command for a sandbox without starting a chat session.

## Changes

**`cmd/cbox/main.go`**:
- Added `openCmd()` function that creates a new Cobra command `cbox open <branch>`
- Registered the command in `main()` alongside existing commands

**`cmd/cbox/open_test.go`** (new):
- Tests that the command requires exactly one branch argument
- Tests that extra arguments are rejected
- Tests that the `--open` flag is properly defined

## How it works

The `cbox open <branch>` command:
1. Loads config from `.cbox.toml`
2. Resolves the open command: `--open` flag value takes precedence, falls back to config's `open` setting
3. Returns an error if no open command is configured (neither flag nor config)
4. Calls the existing `runOpenCommand()` which loads sandbox state, sets `$Dir` to the worktree path, and executes the command via `sh -c`

This matches the behavior of `cbox chat --open` — the same `runOpenCommand()` function is used — but without launching an interactive chat session afterward.

## Test results

All tests pass (`go test ./...`), build succeeds (`go build -o bin/cbox ./cmd/cbox`).