### PR TITLE
Check merge status with loading spinner in flow status

### DIFF
--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -1,0 +1,119 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// spinnerFrames are the characters cycled through for the spinner animation.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// LineSpinner manages a set of lines where some have a spinning indicator
+// that updates in-place until resolved.
+type LineSpinner struct {
+	mu    sync.Mutex
+	w     io.Writer
+	lines []spinnerLine
+	done  chan struct{}
+	frame int
+}
+
+type spinnerLine struct {
+	text     string // the full line text (with %s placeholder for status)
+	status   string // resolved status text, empty while spinning
+	resolved bool
+}
+
+// NewLineSpinner creates a spinner that writes to stdout.
+func NewLineSpinner(count int) *LineSpinner {
+	return &LineSpinner{
+		w:     os.Stdout,
+		lines: make([]spinnerLine, count),
+		done:  make(chan struct{}),
+	}
+}
+
+// SetLine sets the format text for a line. The text should contain one %s
+// placeholder where the status (spinner or resolved value) will be inserted.
+func (s *LineSpinner) SetLine(index int, text string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lines[index].text = text
+}
+
+// Resolve replaces the spinner on the given line with a final status string.
+func (s *LineSpinner) Resolve(index int, status string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lines[index].status = status
+	s.lines[index].resolved = true
+
+	// Check if all lines are resolved
+	allDone := true
+	for _, l := range s.lines {
+		if !l.resolved {
+			allDone = false
+			break
+		}
+	}
+	if allDone {
+		select {
+		case <-s.done:
+		default:
+			close(s.done)
+		}
+	}
+}
+
+// Run starts the spinner animation. It prints all lines initially, then
+// updates them in-place at ~80ms intervals. It blocks until all lines are
+// resolved or the returned stop function is called.
+func (s *LineSpinner) Run() {
+	s.mu.Lock()
+	// Print all lines initially
+	for _, l := range s.lines {
+		status := progressPrefix.Render(spinnerFrames[0])
+		if l.resolved {
+			status = l.status
+		}
+		fmt.Fprintf(s.w, "%s\n", fmt.Sprintf(l.text, status))
+	}
+	s.mu.Unlock()
+
+	ticker := time.NewTicker(80 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-s.done:
+			s.redraw()
+			return
+		case <-ticker.C:
+			s.frame++
+			s.redraw()
+		}
+	}
+}
+
+// redraw moves the cursor up and reprints all lines.
+func (s *LineSpinner) redraw() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	n := len(s.lines)
+	// Move cursor up n lines
+	fmt.Fprintf(s.w, "\033[%dA", n)
+
+	frameChar := spinnerFrames[s.frame%len(spinnerFrames)]
+	for _, l := range s.lines {
+		status := progressPrefix.Render(frameChar)
+		if l.resolved {
+			status = l.status
+		}
+		// Clear line and print
+		fmt.Fprintf(s.w, "\033[2K%s\n", fmt.Sprintf(l.text, status))
+	}
+}

--- a/internal/output/spinner_test.go
+++ b/internal/output/spinner_test.go
@@ -1,0 +1,104 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLineSpinner_AllResolvedBeforeRun(t *testing.T) {
+	spinner := NewLineSpinner(2)
+	spinner.SetLine(0, "line-a %s done")
+	spinner.SetLine(1, "line-b %s done")
+	spinner.Resolve(0, "OK")
+	spinner.Resolve(1, "OK")
+
+	var buf bytes.Buffer
+	spinner.w = &buf
+	spinner.Run()
+
+	out := buf.String()
+	if !strings.Contains(out, "line-a OK done") {
+		t.Errorf("expected line-a with OK, got: %s", out)
+	}
+	if !strings.Contains(out, "line-b OK done") {
+		t.Errorf("expected line-b with OK, got: %s", out)
+	}
+}
+
+func TestLineSpinner_ResolvesDuringRun(t *testing.T) {
+	spinner := NewLineSpinner(2)
+	spinner.SetLine(0, "first %s")
+	spinner.SetLine(1, "second %s")
+
+	var buf bytes.Buffer
+	spinner.w = &buf
+
+	// Resolve immediately after Run starts — the spinner should exit
+	// once all lines are resolved.
+	go func() {
+		spinner.Resolve(0, "done0")
+		spinner.Resolve(1, "done1")
+	}()
+
+	spinner.Run()
+
+	out := buf.String()
+	// The final redraw should contain the resolved values
+	if !strings.Contains(out, "first done0") {
+		t.Errorf("expected resolved line 0, got: %s", out)
+	}
+	if !strings.Contains(out, "second done1") {
+		t.Errorf("expected resolved line 1, got: %s", out)
+	}
+}
+
+func TestLineSpinner_SingleLine(t *testing.T) {
+	spinner := NewLineSpinner(1)
+	spinner.SetLine(0, "status: %s")
+	spinner.Resolve(0, "merged")
+
+	var buf bytes.Buffer
+	spinner.w = &buf
+	spinner.Run()
+
+	out := buf.String()
+	if !strings.Contains(out, "status: merged") {
+		t.Errorf("expected resolved status, got: %s", out)
+	}
+}
+
+func TestLineSpinner_PartialResolve(t *testing.T) {
+	spinner := NewLineSpinner(3)
+	spinner.SetLine(0, "a %s")
+	spinner.SetLine(1, "b %s")
+	spinner.SetLine(2, "c %s")
+
+	var buf bytes.Buffer
+	spinner.w = &buf
+
+	// Only resolving 2 of 3 initially — spinner should keep running
+	spinner.Resolve(0, "ok")
+
+	done := make(chan struct{})
+	go func() {
+		spinner.Run()
+		close(done)
+	}()
+
+	// Resolve remaining
+	spinner.Resolve(1, "ok")
+	spinner.Resolve(2, "ok")
+	<-done
+
+	out := buf.String()
+	if !strings.Contains(out, "a ok") {
+		t.Errorf("expected line a resolved, got: %s", out)
+	}
+	if !strings.Contains(out, "b ok") {
+		t.Errorf("expected line b resolved, got: %s", out)
+	}
+	if !strings.Contains(out, "c ok") {
+		t.Errorf("expected line c resolved, got: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Replaced the sequential, blocking PR status fetching in `cbox flow status` with concurrent fetches that show animated loading spinners while waiting.

## Changes

### New file: `internal/output/spinner.go`
- `LineSpinner` type that manages multiple terminal lines with in-place updates
- Uses braille spinner characters (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) animated at 80ms intervals
- ANSI escape codes (`\033[nA` cursor up, `\033[2K` clear line) for in-place redraw
- Thread-safe: `SetLine()`, `Resolve()` can be called from goroutines
- `Run()` blocks until all lines are resolved

### New file: `internal/output/spinner_test.go`
- Tests for pre-resolved lines, concurrent resolution, single line, and partial resolution scenarios

### Modified: `internal/workflow/workflow.go`
- **List view** (`FlowStatus` without branch arg): Prints all flow rows immediately with spinners in the phase column, fetches PR statuses concurrently via goroutines, updates each line in-place when its fetch completes
- **Detail view** (`printFlowState` with specific branch): Shows a spinner on the Phase line while fetching PR status
- Optimization: Skips spinner overhead entirely when no flows have PR numbers to check

## Behavior

Before: Each row printed one at a time, blocking on the `gh pr view` API call for each flow sequentially.

After: All rows appear instantly. Flows without PRs show their phase immediately. Flows with PRs show an animated spinner (`⠋ ⠙ ⠹ ...`) that resolves to the actual status (`merged`, `pr-open`, `pr-closed`) as each concurrent API call completes.

## Tests

All existing tests pass. New spinner tests cover the core animation and resolution logic.