### PR TITLE
Docker build output formatting interferes with line updates

### DIFF
--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -65,11 +65,11 @@ func BuildClaudeImage(imageName string, opts BuildOptions) error {
 	buildArgs = append(buildArgs, tmpDir)
 
 	cmd := exec.Command("docker", buildArgs...)
-	cw := output.NewCommandWriter(os.Stdout)
-	cmd.Stdout = cw
-	cmd.Stderr = cw
+	pw := output.NewPassthroughWriter(os.Stdout)
+	cmd.Stdout = pw
+	cmd.Stderr = pw
 	err = cmd.Run()
-	cw.Close()
+	pw.Close()
 	if err != nil {
 		return fmt.Errorf("building claude image: %w", err)
 	}

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -97,7 +97,10 @@ func Text(format string, args ...any) {
 
 // CommandWriter wraps an io.Writer and prepends a dim "│ " border to each
 // line of output. It is used to visually frame third-party command output
-// (e.g. docker build logs) so it's easy to distinguish from cbox messages.
+// (e.g. docker run) so it's easy to distinguish from cbox messages.
+//
+// For commands with complex terminal output that uses carriage returns for
+// in-place line updates (e.g. docker build), use NewPassthroughWriter instead.
 type CommandWriter struct {
 	w    io.Writer
 	buf  []byte
@@ -136,3 +139,29 @@ func (cw *CommandWriter) Close() {
 		cw.buf = nil
 	}
 }
+
+// PassthroughWriter forwards command output directly to the underlying writer
+// without adding border decorations. It adds a leading blank line for visual
+// separation, then passes bytes through unchanged. This preserves terminal
+// control sequences (e.g. carriage returns for in-place line updates) used by
+// commands like docker build.
+type PassthroughWriter struct {
+	w    io.Writer
+	once sync.Once
+}
+
+// NewPassthroughWriter returns a PassthroughWriter that forwards output to w
+// without border decoration.
+func NewPassthroughWriter(w io.Writer) *PassthroughWriter {
+	return &PassthroughWriter{w: w}
+}
+
+func (pw *PassthroughWriter) Write(p []byte) (int, error) {
+	pw.once.Do(func() {
+		fmt.Fprintln(pw.w)
+	})
+	return pw.w.Write(p)
+}
+
+// Close is a no-op; PassthroughWriter does not buffer.
+func (pw *PassthroughWriter) Close() {}


### PR DESCRIPTION
## Summary

Docker build output uses carriage returns (`\r`) for in-place line updates — for example, showing a build step and then replacing it with "CACHED" on the same line. The `CommandWriter` introduced in PR #53 breaks this by splitting output on `\n` and prepending a `│ ` border to each line, which prevents the terminal from performing line replacements. This results in doubled lines in the output.

## Changes

**`internal/output/render.go`**
- Added `PassthroughWriter` — a lightweight writer that forwards output directly without adding border decorations. It preserves terminal control sequences (carriage returns, ANSI escapes) while still adding a leading blank line for visual separation from cbox messages.
- Updated `CommandWriter` docs to clarify when to use each writer.

**`internal/docker/build.go`**
- Switched `BuildClaudeImage` from `CommandWriter` to `PassthroughWriter` so docker build output flows through unchanged.

**`internal/output/render_test.go`**
- `TestPassthroughWriter` — verifies output has no border and content passes through
- `TestPassthroughWriterPreservesControlChars` — verifies carriage returns are preserved (the core fix)
- `TestPassthroughWriterLeadingBlankLine` — verifies the visual separator is still added

## Design decisions

- `docker run -d` (in `container.go`) still uses `CommandWriter` since it only outputs a container ID — simple, single-line output where the border is appropriate.
- `PassthroughWriter` keeps the leading blank line from `CommandWriter` for consistent visual separation between cbox progress messages and command output.

All tests pass, build succeeds.