### PR TITLE
Show closed PR status in flow status command

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,7 +75,7 @@ func DefaultWorkflowConfig() *WorkflowConfig {
 		PR: &WorkflowPRConfig{
 			Create: `gh pr create --title "$Title" --body "$Description"`,
 			Merge:  `gh pr merge "$PRNumber" --merge`,
-			View:   `gh pr view "$PRNumber" --json number,state,title,url,mergedAt`,
+			View:   `gh pr view "$PRNumber" --json number,state,title,url,mergedAt,closedAt`,
 		},
 	}
 }

--- a/internal/workflow/taskfile.go
+++ b/internal/workflow/taskfile.go
@@ -109,6 +109,7 @@ type PRStatus struct {
 	Title    string
 	URL      string
 	MergedAt string
+	ClosedAt string
 }
 
 // parsePRJSON parses the JSON output from `gh pr view --json`.
@@ -119,6 +120,7 @@ func parsePRJSON(jsonStr string) (*PRStatus, error) {
 		Title    string `json:"title"`
 		URL      string `json:"url"`
 		MergedAt string `json:"mergedAt"`
+		ClosedAt string `json:"closedAt"`
 	}
 
 	if err := json.Unmarshal([]byte(jsonStr), &raw); err != nil {
@@ -131,6 +133,7 @@ func parsePRJSON(jsonStr string) (*PRStatus, error) {
 		Title:    raw.Title,
 		URL:      raw.URL,
 		MergedAt: raw.MergedAt,
+		ClosedAt: raw.ClosedAt,
 	}, nil
 }
 

--- a/internal/workflow/taskfile_test.go
+++ b/internal/workflow/taskfile_test.go
@@ -114,6 +114,58 @@ func TestParsePRJSON_Open(t *testing.T) {
 	}
 }
 
+func TestParsePRJSON_Closed(t *testing.T) {
+	input := `{
+		"number": 15,
+		"state": "CLOSED",
+		"title": "Abandoned feature",
+		"url": "https://github.com/owner/repo/pull/15",
+		"mergedAt": "",
+		"closedAt": "2025-02-10T14:00:00Z"
+	}`
+
+	status, err := parsePRJSON(input)
+	if err != nil {
+		t.Fatalf("parsePRJSON failed: %v", err)
+	}
+
+	if status.State != "CLOSED" {
+		t.Errorf("State = %q, want %q", status.State, "CLOSED")
+	}
+	if status.MergedAt != "" {
+		t.Errorf("MergedAt = %q, want empty", status.MergedAt)
+	}
+	if status.ClosedAt != "2025-02-10T14:00:00Z" {
+		t.Errorf("ClosedAt = %q, want %q", status.ClosedAt, "2025-02-10T14:00:00Z")
+	}
+}
+
+func TestParsePRJSON_MergedWithClosedAt(t *testing.T) {
+	input := `{
+		"number": 42,
+		"state": "MERGED",
+		"title": "Add feature X",
+		"url": "https://github.com/owner/repo/pull/42",
+		"mergedAt": "2025-01-15T10:30:00Z",
+		"closedAt": "2025-01-15T10:30:00Z"
+	}`
+
+	status, err := parsePRJSON(input)
+	if err != nil {
+		t.Fatalf("parsePRJSON failed: %v", err)
+	}
+
+	if status.State != "MERGED" {
+		t.Errorf("State = %q, want %q", status.State, "MERGED")
+	}
+	if status.MergedAt != "2025-01-15T10:30:00Z" {
+		t.Errorf("MergedAt = %q, want %q", status.MergedAt, "2025-01-15T10:30:00Z")
+	}
+	if status.ClosedAt != "2025-01-15T10:30:00Z" {
+		t.Errorf("ClosedAt = %q, want %q", status.ClosedAt, "2025-01-15T10:30:00Z")
+	}
+}
+
 func TestParsePRJSON_InvalidJSON(t *testing.T) {
 	_, err := parsePRJSON("not json")
 	if err == nil {

--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -625,7 +625,7 @@ func formatPRPhase(prStatus *PRStatus) string {
 	case "MERGED":
 		return "merged"
 	case "CLOSED":
-		return "pr-closed"
+		return "closed"
 	case "OPEN":
 		return "pr-open"
 	default:
@@ -641,12 +641,14 @@ func printFlowState(projectDir string, wf *config.WorkflowConfig, s *FlowState) 
 	}
 
 	// Use a spinner if we need to fetch PR status
+	var fetchedPR *PRStatus
 	if s.PRNumber != "" {
 		spinner := output.NewLineSpinner(1)
 		spinner.SetLine(0, "Phase:       %s")
 		go func() {
 			phase := s.Phase
 			if prStatus, err := fetchPRStatus(wf, s); err == nil && prStatus != nil {
+				fetchedPR = prStatus
 				phase = formatPRPhase(prStatus)
 			}
 			spinner.Resolve(0, phase)
@@ -661,6 +663,16 @@ func printFlowState(projectDir string, wf *config.WorkflowConfig, s *FlowState) 
 	}
 	if s.PRURL != "" {
 		output.Text("PR:          %s", s.PRURL)
+	}
+
+	// Show merge/close timestamps when available
+	if fetchedPR != nil {
+		if fetchedPR.MergedAt != "" {
+			output.Text("Merged at:   %s", fetchedPR.MergedAt)
+		}
+		if fetchedPR.ClosedAt != "" {
+			output.Text("Closed at:   %s", fetchedPR.ClosedAt)
+		}
 	}
 
 	output.Text("Auto mode:   %v", s.AutoMode)

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -14,7 +14,7 @@ func TestFormatPRPhase(t *testing.T) {
 	}{
 		{"merged", "MERGED", "merged"},
 		{"open", "OPEN", "pr-open"},
-		{"closed", "CLOSED", "pr-closed"},
+		{"closed", "CLOSED", "closed"},
 		{"lowercase merged", "merged", "merged"},
 		{"unknown state", "DRAFT", "draft"},
 	}


### PR DESCRIPTION
## Changes

### Problem
The `flow status` command showed "merged" for merged PRs but used "pr-closed" for closed PRs. The user wanted closed PRs to be clearly shown with a consistent label and additional timestamp details.

### What changed

**4 files modified, 2 test files updated:**

1. **`internal/workflow/taskfile.go`** — Added `ClosedAt` field to `PRStatus` struct and `parsePRJSON` to capture the `closedAt` timestamp from GitHub's PR JSON response.

2. **`internal/config/config.go`** — Added `closedAt` to the default `gh pr view --json` fields so the closed timestamp is fetched alongside the existing `mergedAt`.

3. **`internal/workflow/workflow.go`** — Two changes:
   - `formatPRPhase`: Changed closed PR label from `"pr-closed"` to `"closed"` for consistency with `"merged"`.
   - `printFlowState`: Added display of `Merged at:` and `Closed at:` timestamps in the detailed single-flow status view when available.

4. **Tests** — Updated `TestFormatPRPhase` for the new `"closed"` label. Added `TestParsePRJSON_Closed` and `TestParsePRJSON_MergedWithClosedAt` tests to cover closed PR parsing including the `closedAt` field.

### How it works

- **Multi-flow listing** (`cbox flow status`): Each flow with a PR now shows `closed` (was `pr-closed`) or `merged` as the phase.
- **Single-flow detail** (`cbox flow status <branch>`): Shows `Merged at:` and/or `Closed at:` timestamps below the PR URL when the PR has been merged or closed.

### Testing
All tests pass (`go test ./...`). Build succeeds.