### PR TITLE
Clean up local resources for merged cbox branches

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -472,6 +472,7 @@ func flowCmd() *cobra.Command {
 	cmd.AddCommand(flowInitCmd())
 	cmd.AddCommand(flowStartCmd())
 	cmd.AddCommand(flowStatusCmd())
+	cmd.AddCommand(flowCleanCmd())
 	cmd.AddCommand(flowChatCmd())
 	cmd.AddCommand(flowPRCmd())
 	cmd.AddCommand(flowMergeCmd())
@@ -535,6 +536,17 @@ func flowStatusCmd() *cobra.Command {
 				branch = args[0]
 			}
 			return workflow.FlowStatus(projectDir(), branch)
+		},
+	}
+}
+
+func flowCleanCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "clean",
+		Short: "Remove local resources for merged flows",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workflow.FlowClean(projectDir())
 		},
 	}
 }

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -1,6 +1,9 @@
 package workflow
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/richvanbergen/cbox/internal/config"
@@ -135,5 +138,266 @@ func TestResolveOpenCommand(t *testing.T) {
 					tt.openFlag, tt.openCmd, tt.configOpen, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFindMergedFlows(t *testing.T) {
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{
+			View: `echo '{"number":$PRNumber,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		},
+	}
+
+	states := []*FlowState{
+		{Branch: "merged-branch", Title: "Merged PR", PRNumber: "1", Phase: "started"},
+		{Branch: "no-pr-branch", Title: "No PR", PRNumber: "", Phase: "started"},
+	}
+
+	merged := findMergedFlows(wf, states)
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged flow, got %d", len(merged))
+	}
+	if merged[0].Branch != "merged-branch" {
+		t.Errorf("expected merged branch 'merged-branch', got %q", merged[0].Branch)
+	}
+}
+
+func TestFindMergedFlows_NonemergedPR(t *testing.T) {
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{
+			View: `echo '{"number":1,"state":"OPEN","title":"t","url":"u","mergedAt":""}'`,
+		},
+	}
+
+	states := []*FlowState{
+		{Branch: "open-branch", Title: "Open PR", PRNumber: "1", Phase: "started"},
+	}
+
+	merged := findMergedFlows(wf, states)
+
+	if len(merged) != 0 {
+		t.Fatalf("expected 0 merged flows, got %d", len(merged))
+	}
+}
+
+func TestFindMergedFlows_Empty(t *testing.T) {
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{
+			View: `echo '{}'`,
+		},
+	}
+
+	merged := findMergedFlows(wf, nil)
+	if len(merged) != 0 {
+		t.Fatalf("expected 0 merged flows for nil states, got %d", len(merged))
+	}
+}
+
+func TestFindMergedFlows_MixedStates(t *testing.T) {
+	// Use a view command that returns MERGED for PRNumber=1 and OPEN for PRNumber=2
+	wf := &config.WorkflowConfig{
+		PR: &config.WorkflowPRConfig{
+			View: `if [ "$PRNumber" = "1" ]; then echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'; else echo '{"number":2,"state":"OPEN","title":"t","url":"u","mergedAt":""}'; fi`,
+		},
+	}
+
+	states := []*FlowState{
+		{Branch: "merged-one", Title: "Merged", PRNumber: "1", Phase: "started"},
+		{Branch: "open-one", Title: "Open", PRNumber: "2", Phase: "started"},
+		{Branch: "no-pr", Title: "No PR", PRNumber: "", Phase: "started"},
+	}
+
+	merged := findMergedFlows(wf, states)
+
+	if len(merged) != 1 {
+		t.Fatalf("expected 1 merged flow, got %d", len(merged))
+	}
+	if merged[0].Branch != "merged-one" {
+		t.Errorf("expected merged branch 'merged-one', got %q", merged[0].Branch)
+	}
+}
+
+// setupFlowCleanDir creates a temp directory with a .cbox.toml config and
+// flow state files for testing flowClean.
+func setupFlowCleanDir(t *testing.T, viewCmd string, states []*FlowState) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Write .cbox.toml
+	toml := `[workflow]
+[workflow.pr]
+view = ` + `"` + viewCmd + `"` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cbox.toml"), []byte(toml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write flow state files
+	for _, s := range states {
+		if err := SaveFlowState(dir, s); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return dir
+}
+
+func TestFlowClean_NoActiveFlows(t *testing.T) {
+	dir := t.TempDir()
+	toml := `[workflow]
+[workflow.pr]
+view = "echo test"
+`
+	if err := os.WriteFile(filepath.Join(dir, ".cbox.toml"), []byte(toml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := flowClean(dir, strings.NewReader("y\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFlowClean_NoWorkflowConfig(t *testing.T) {
+	dir := t.TempDir()
+	toml := "[commands]\nbuild = \"echo build\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".cbox.toml"), []byte(toml), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := flowClean(dir, strings.NewReader("y\n"))
+	if err == nil {
+		t.Error("expected error when no workflow config")
+	}
+}
+
+func TestFlowClean_UserDeclinesConfirmation(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		[]*FlowState{
+			{Branch: "test-branch", Title: "Test", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	// User answers "n" — flow state should NOT be removed
+	err := flowClean(dir, strings.NewReader("n\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Flow state should still exist
+	_, err = LoadFlowState(dir, "test-branch")
+	if err != nil {
+		t.Errorf("flow state should still exist after declining: %v", err)
+	}
+}
+
+func TestFlowClean_UserConfirmsRemoval(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		[]*FlowState{
+			{Branch: "test-branch", Title: "Test", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	// User answers "y" — flow state should be removed
+	// sandbox.Clean will fail (no sandbox state file), but FlowClean warns and continues
+	err := flowClean(dir, strings.NewReader("y\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Flow state should be removed
+	_, err = LoadFlowState(dir, "test-branch")
+	if err == nil {
+		t.Error("flow state should have been removed after confirming")
+	}
+}
+
+func TestFlowClean_UserConfirmsYes(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		[]*FlowState{
+			{Branch: "test-branch", Title: "Test", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	// "yes" should also work
+	err := flowClean(dir, strings.NewReader("yes\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = LoadFlowState(dir, "test-branch")
+	if err == nil {
+		t.Error("flow state should have been removed after confirming 'yes'")
+	}
+}
+
+func TestFlowClean_NoMergedFlows(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"OPEN","title":"t","url":"u","mergedAt":""}'`,
+		[]*FlowState{
+			{Branch: "open-branch", Title: "Open", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	err := flowClean(dir, strings.NewReader("y\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Flow state should still exist since nothing was merged
+	_, err = LoadFlowState(dir, "open-branch")
+	if err != nil {
+		t.Errorf("flow state should still exist: %v", err)
+	}
+}
+
+func TestFlowClean_RemovesReportsDir(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		[]*FlowState{
+			{Branch: "test-branch", Title: "Test", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	// Create a reports directory
+	repDir := reportDir(dir, "test-branch")
+	if err := os.MkdirAll(repDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repDir, "001-done.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := flowClean(dir, strings.NewReader("y\n"))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Reports directory should be removed
+	if _, err := os.Stat(repDir); !os.IsNotExist(err) {
+		t.Error("reports directory should have been removed")
+	}
+}
+
+func TestFlowClean_EmptyInput(t *testing.T) {
+	dir := setupFlowCleanDir(t,
+		`echo '{"number":1,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+		[]*FlowState{
+			{Branch: "test-branch", Title: "Test", PRNumber: "1", Phase: "started"},
+		},
+	)
+
+	// Empty input (EOF) should not clean up
+	err := flowClean(dir, strings.NewReader(""))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = LoadFlowState(dir, "test-branch")
+	if err != nil {
+		t.Errorf("flow state should still exist after EOF: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Added `cbox flow clean` command that cleans up local resources (worktrees, containers, flow state, reports) for flows whose PRs have been merged.

## Changes

### `internal/workflow/workflow.go`
- Added `FlowClean(projectDir)` — public entry point that reads from stdin
- Added `flowClean(projectDir, confirmReader)` — internal implementation accepting an `io.Reader` for testability
- Added `findMergedFlows(wf, states)` — fetches PR status concurrently for all active flows and returns those in MERGED state

### `cmd/cbox/main.go`
- Added `flowCleanCmd()` — registers `cbox flow clean` as a subcommand under `flow`

### `internal/workflow/workflow_test.go`
- Added 11 new tests covering:
  - `findMergedFlows`: merged detection, non-merged PRs, empty state list, mixed states
  - `flowClean`: no active flows, missing workflow config, user declines confirmation, user confirms with "y", user confirms with "yes", no merged flows, reports directory removal, empty input (EOF)

## How it works

1. Loads all active flow states from `.cbox/flow-*.json`
2. Fetches PR status concurrently (with spinners) for flows that have a PR number
3. Identifies flows whose PRs are in MERGED state
4. Lists what will be removed and prompts: "Remove these flows? [y/N]"
5. On confirmation, for each merged flow:
   - Calls `sandbox.Clean()` to stop container, remove network, worktree, and branch
   - Removes the flow state file
   - Removes the reports directory

## Test plan
- All existing tests pass
- New tests verify merged flow identification, confirmation prompt behavior (accept/decline/EOF), and cleanup side effects (flow state removal, reports directory removal)