### PR TITLE
Convert cbox flow output newline formatting

### DIFF
--- a/internal/docker/build.go
+++ b/internal/docker/build.go
@@ -65,7 +65,9 @@ func BuildClaudeImage(imageName string, opts BuildOptions) error {
 	cmd := exec.Command("docker", buildArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	fmt.Fprintln(os.Stdout)
 	err = cmd.Run()
+	fmt.Fprintln(os.Stdout)
 	if err != nil {
 		return fmt.Errorf("building claude image: %w", err)
 	}

--- a/internal/output/render_test.go
+++ b/internal/output/render_test.go
@@ -234,6 +234,14 @@ func TestCommandWriter(t *testing.T) {
 	if contentLines != 2 {
 		t.Errorf("expected 2 bordered lines, got %d in %q", contentLines, got)
 	}
+
+	// Verify blank line before and after output for visual separation
+	if !strings.HasPrefix(got, "\n") {
+		t.Errorf("expected leading blank line, got %q", got)
+	}
+	if !strings.HasSuffix(got, "\n\n") {
+		t.Errorf("expected trailing blank line, got %q", got)
+	}
 }
 
 func TestCommandWriterPartialLines(t *testing.T) {
@@ -264,6 +272,17 @@ func TestCommandWriterFlushOnClose(t *testing.T) {
 	}
 	if !strings.Contains(got, "no newline") {
 		t.Errorf("expected 'no newline' in output, got %q", got)
+	}
+}
+
+func TestCommandWriterCloseWithoutWrite(t *testing.T) {
+	var buf bytes.Buffer
+	cw := NewCommandWriter(&buf)
+	cw.Close()
+	got := buf.String()
+
+	if got != "" {
+		t.Errorf("expected no output when Close is called without Write, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

Command output from `cbox flow start` had inconsistent newline formatting:

1. **Docker build output** (via direct `os.Stdout`) had no blank lines before or after — the build output ran directly into surrounding progress messages.
2. **Container ID output** (via `CommandWriter`) had a blank line before but not after — the next progress message appeared immediately after the bordered output.

## Changes

### `internal/output/render.go`
- Added `wrote` field to `CommandWriter` to track whether `Write()` was called
- `Close()` now emits a trailing blank line when output was written, matching the leading blank line already emitted by `Write()` via `sync.Once`
- No output emitted if `Close()` is called without any prior `Write()` calls

### `internal/docker/build.go`
- Added `fmt.Fprintln(os.Stdout)` before and after `cmd.Run()` in `BuildClaudeImage` to frame docker build output with blank lines

### `internal/output/render_test.go`
- Extended `TestCommandWriter` to verify leading and trailing blank lines
- Added `TestCommandWriterCloseWithoutWrite` to verify no output when `Close()` is called without `Write()`

## Result

Before:
```
› Building Claude image cbox-cbox:claude
[+] Building 1.3s (18/18) FINISHED
...
View build details: docker-desktop://...
› Creating network cbox-cbox-branch
...
› Starting Claude container cbox-cbox-branch-claude

│ 629bb5c28a0b...
› Injecting system CLAUDE.md
```

After:
```
› Building Claude image cbox-cbox:claude

[+] Building 1.3s (18/18) FINISHED
...
View build details: docker-desktop://...

› Creating network cbox-cbox-branch
...
› Starting Claude container cbox-cbox-branch-claude

│ 629bb5c28a0b...

› Injecting system CLAUDE.md
```

Build passes. All tests pass.