### PR TITLE
Say hello in some fashion

### DIFF
--- a/cmd/cbox/hello_test.go
+++ b/cmd/cbox/hello_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestHelloCmd(t *testing.T) {
+	cmd := helloCmd()
+	if cmd.Use != "hello" {
+		t.Errorf("Use = %q, want %q", cmd.Use, "hello")
+	}
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("hello command returned error: %v", err)
+	}
+}

--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -27,6 +27,7 @@ func main() {
 		SilenceErrors: true,
 	}
 
+	root.AddCommand(helloCmd())
 	root.AddCommand(initCmd())
 	root.AddCommand(upCmd())
 	root.AddCommand(downCmd())
@@ -137,6 +138,16 @@ func configCommandCompletion() func(*cobra.Command, []string, string) ([]string,
 			}
 		}
 		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func helloCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "hello",
+		Short: "Say hello",
+		Run: func(cmd *cobra.Command, args []string) {
+			output.Success("Hello from cbox!")
+		},
 	}
 }
 


### PR DESCRIPTION
## Changes

Added a `cbox hello` command that prints a styled greeting message: "Hello from cbox!"

### Files changed

- **cmd/cbox/main.go**: Added `helloCmd()` function and registered it with the root command
- **cmd/cbox/hello_test.go**: New test file verifying the command's `Use` field and that it executes without error

### Testing

- All existing tests pass (`go test ./...`)
- Build succeeds (`go build -o bin/cbox ./cmd/cbox`)
- The command appears correctly in `cbox --help` output