### PR TITLE
Unclear task request

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -682,6 +682,7 @@ func mcpProxyCmd() *cobra.Command {
 	var reportDir string
 	var flowProjectDir string
 	var flowBranch string
+	var timeoutSeconds int
 
 	cmd := &cobra.Command{
 		Use:    "_mcp-proxy [host-commands...]",
@@ -701,7 +702,7 @@ func mcpProxyCmd() *cobra.Command {
 					Branch:     flowBranch,
 				}
 			}
-			return hostcmd.RunProxyCommand(worktreePath, args, namedCommands, reportDir, flow)
+			return hostcmd.RunProxyCommand(worktreePath, args, namedCommands, reportDir, flow, timeoutSeconds)
 		},
 	}
 
@@ -711,6 +712,7 @@ func mcpProxyCmd() *cobra.Command {
 	cmd.Flags().StringVar(&reportDir, "report-dir", "", "Directory for cbox_report tool output")
 	cmd.Flags().StringVar(&flowProjectDir, "flow-project-dir", "", "Project dir for flow commands")
 	cmd.Flags().StringVar(&flowBranch, "flow-branch", "", "Branch name for flow commands")
+	cmd.Flags().IntVar(&timeoutSeconds, "timeout", 0, "Command timeout in seconds (default 120)")
 	return cmd
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Dockerfile   string            `toml:"dockerfile,omitempty"`
 	Open         string            `toml:"open,omitempty"`
 	Editor       string            `toml:"editor,omitempty"`
+	Timeout      int               `toml:"timeout,omitempty"` // Command timeout in seconds (default 120)
 	Workflow     *WorkflowConfig   `toml:"workflow,omitempty"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -147,6 +147,58 @@ func TestLoad_PrefersNewOverLegacy(t *testing.T) {
 	}
 }
 
+func TestLoad_TimeoutField(t *testing.T) {
+	dir := t.TempDir()
+	content := `timeout = 300` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Timeout != 300 {
+		t.Errorf("Timeout = %d, want 300", cfg.Timeout)
+	}
+}
+
+func TestLoad_NoTimeoutDefaultsToZero(t *testing.T) {
+	dir := t.TempDir()
+	content := `host_commands = ["git"]` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ConfigFile), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if cfg.Timeout != 0 {
+		t.Errorf("Timeout = %d, want 0 (unset)", cfg.Timeout)
+	}
+}
+
+func TestSaveAndLoad_RoundTripTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := DefaultConfig()
+	cfg.Timeout = 600
+	if err := cfg.Save(dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	if loaded.Timeout != 600 {
+		t.Errorf("Timeout = %d, want 600", loaded.Timeout)
+	}
+}
+
 func TestSaveAndLoad_RoundTripCopyFiles(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/hostcmd/run.go
+++ b/internal/hostcmd/run.go
@@ -14,8 +14,9 @@ type proxyOutput struct {
 }
 
 // RunProxyCommand starts the MCP server, prints the port as JSON, and blocks until signaled.
-func RunProxyCommand(worktreePath string, commands []string, namedCommands map[string]string, reportDir string, flow *FlowConfig) error {
-	srv := NewServer(worktreePath, commands, namedCommands)
+// timeoutSeconds sets the per-command timeout; 0 uses the default (120s).
+func RunProxyCommand(worktreePath string, commands []string, namedCommands map[string]string, reportDir string, flow *FlowConfig, timeoutSeconds int) error {
+	srv := NewServer(worktreePath, commands, namedCommands, timeoutSeconds)
 	if reportDir != "" {
 		srv.SetReportDir(reportDir)
 	}

--- a/internal/sandbox/state.go
+++ b/internal/sandbox/state.go
@@ -12,7 +12,12 @@ import (
 
 const StateDir = ".cbox"
 
+// StateVersion is the current schema version for sandbox state files.
+// Bump this when the State struct changes in a backward-incompatible way.
+const StateVersion = 1
+
 type State struct {
+	Version         int                   `json:"version"`
 	ClaudeContainer string                `json:"claude_container"`
 	NetworkName     string                `json:"network_name"`
 	WorktreePath    string                `json:"worktree_path"`
@@ -50,6 +55,8 @@ func SaveState(projectDir, branch string, s *State) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("creating state dir: %w", err)
 	}
+
+	s.Version = StateVersion
 
 	data, err := json.MarshalIndent(s, "", "  ")
 	if err != nil {

--- a/internal/workflow/state.go
+++ b/internal/workflow/state.go
@@ -11,7 +11,12 @@ import (
 
 const stateDir = ".cbox"
 
+// FlowStateVersion is the current schema version for flow state files.
+// Bump this when the FlowState struct changes in a backward-incompatible way.
+const FlowStateVersion = 1
+
 type FlowState struct {
+	Version     int       `json:"version"`
 	Branch      string    `json:"branch"`
 	Title       string    `json:"title"`
 	Description string    `json:"description,omitempty"`
@@ -50,6 +55,7 @@ func SaveFlowState(projectDir string, s *FlowState) error {
 		return fmt.Errorf("creating state dir: %w", err)
 	}
 
+	s.Version = FlowStateVersion
 	s.UpdatedAt = time.Now()
 
 	data, err := json.MarshalIndent(s, "", "  ")

--- a/internal/workflow/state_test.go
+++ b/internal/workflow/state_test.go
@@ -1,0 +1,122 @@
+package workflow
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSaveFlowStateSetsVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	state := &FlowState{
+		Branch:    "test-branch",
+		Title:     "Test",
+		Phase:     "started",
+		CreatedAt: time.Now(),
+	}
+
+	if err := SaveFlowState(dir, state); err != nil {
+		t.Fatalf("SaveFlowState: %v", err)
+	}
+
+	if state.Version != FlowStateVersion {
+		t.Errorf("state.Version = %d, want %d", state.Version, FlowStateVersion)
+	}
+
+	loaded, err := LoadFlowState(dir, "test-branch")
+	if err != nil {
+		t.Fatalf("LoadFlowState: %v", err)
+	}
+
+	if loaded.Version != FlowStateVersion {
+		t.Errorf("loaded.Version = %d, want %d", loaded.Version, FlowStateVersion)
+	}
+}
+
+func TestLoadFlowStateLegacyNoVersion(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a flow state file without the version field.
+	stateJSON := `{
+  "branch": "old-branch",
+  "title": "Old Task",
+  "phase": "started",
+  "auto_mode": false,
+  "chatted": false,
+  "created_at": "2025-01-01T00:00:00Z",
+  "updated_at": "2025-01-01T00:00:00Z"
+}`
+	stateDir := filepath.Join(dir, ".cbox")
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(stateDir, "flow-old-branch.json")
+	if err := os.WriteFile(path, []byte(stateJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadFlowState(dir, "old-branch")
+	if err != nil {
+		t.Fatalf("LoadFlowState: %v", err)
+	}
+
+	if loaded.Version != 0 {
+		t.Errorf("loaded.Version = %d, want 0 for legacy file", loaded.Version)
+	}
+	if loaded.Title != "Old Task" {
+		t.Errorf("loaded.Title = %q, want %q", loaded.Title, "Old Task")
+	}
+}
+
+func TestSaveFlowStateVersionInJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	state := &FlowState{
+		Branch:    "json-check",
+		Title:     "Check",
+		Phase:     "started",
+		CreatedAt: time.Now(),
+	}
+
+	if err := SaveFlowState(dir, state); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, ".cbox", "flow-json-check.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := raw["version"]; !ok {
+		t.Error("expected 'version' key in serialized flow state JSON")
+	}
+}
+
+func TestSaveFlowStateUpdatesTimestamp(t *testing.T) {
+	dir := t.TempDir()
+
+	before := time.Now().Add(-time.Second)
+	state := &FlowState{
+		Branch:    "ts-check",
+		Title:     "Timestamp",
+		Phase:     "started",
+		CreatedAt: before,
+	}
+
+	if err := SaveFlowState(dir, state); err != nil {
+		t.Fatal(err)
+	}
+
+	if !state.UpdatedAt.After(before) {
+		t.Errorf("UpdatedAt should be after creation time")
+	}
+}


### PR DESCRIPTION
## Changes

Three improvements to the cbox codebase:

### 1. State file versioning
- Added `Version` field to both `State` (sandbox) and `FlowState` (workflow) structs
- `SaveState` and `SaveFlowState` now stamp the current version (`1`) on every write
- Legacy state files without a version field load correctly (version defaults to `0`)
- This enables future schema migrations by checking the version before unmarshaling

**Files:** `internal/sandbox/state.go`, `internal/workflow/state.go`

### 2. Configurable command timeout
- Added `timeout` field to `Config` struct (in seconds, via `cbox.toml`)
- The `hostcmd.Server` now accepts a timeout parameter instead of using a hardcoded 120s constant
- Timeout propagates through `startMCPProxy` → `_mcp-proxy` CLI flag → `NewServer`
- Default remains 120 seconds when not configured
- Timeout error messages now include the actual configured value

**Files:** `internal/config/config.go`, `internal/hostcmd/server.go`, `internal/hostcmd/run.go`, `internal/sandbox/sandbox.go`, `cmd/cbox/main.go`

### 3. Bounded concurrency for PR status fetches
- Added `maxPRFetchConcurrency = 5` semaphore to `FlowStatus` and `findMergedFlows`
- Prevents unbounded goroutine spawning when many flows are active
- Uses a buffered channel as a counting semaphore

**Files:** `internal/workflow/workflow.go`

### Tests added
- `TestSaveStateSetsVersion`, `TestLoadStateLegacyNoVersion`, `TestSaveStateVersionInJSON` (sandbox state)
- `TestSaveFlowStateSetsVersion`, `TestLoadFlowStateLegacyNoVersion`, `TestSaveFlowStateVersionInJSON`, `TestSaveFlowStateUpdatesTimestamp` (flow state)
- `TestNewServerDefaultTimeout`, `TestNewServerCustomTimeout`, `TestNewServerNegativeTimeoutUsesDefault` (hostcmd)
- `TestLoad_TimeoutField`, `TestLoad_NoTimeoutDefaultsToZero`, `TestSaveAndLoad_RoundTripTimeout` (config)

All existing and new tests pass. Build succeeds cleanly.