### PR TITLE
Fix flow abandon spinner display on completion

### DIFF
--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -507,7 +507,7 @@ func FlowMerge(projectDir, branch string) error {
 
 	// Clean up sandbox
 	if err := output.Spin("Cleaning up sandbox", func() error {
-		return sandbox.Clean(projectDir, branch)
+		return sandbox.CleanQuiet(projectDir, branch)
 	}); err != nil {
 		output.Warning("Sandbox cleanup failed: %v", err)
 	}
@@ -700,7 +700,7 @@ func flowClean(projectDir string, confirmReader io.Reader) error {
 	for _, s := range merged {
 		branchName := s.Branch
 		if err := output.Spin(fmt.Sprintf("Cleaning up %s", branchName), func() error {
-			return sandbox.Clean(projectDir, branchName)
+			return sandbox.CleanQuiet(projectDir, branchName)
 		}); err != nil {
 			output.Warning("Sandbox cleanup failed for %s: %v", branchName, err)
 		}
@@ -866,7 +866,7 @@ func FlowAbandon(projectDir, branch string) error {
 
 	// Clean up sandbox
 	if err := output.Spin("Cleaning up sandbox", func() error {
-		return sandbox.Clean(projectDir, branch)
+		return sandbox.CleanQuiet(projectDir, branch)
 	}); err != nil {
 		output.Warning("Sandbox cleanup failed: %v", err)
 	}


### PR DESCRIPTION
## Problem

When running `cbox flow abandon`, `flow merge`, or `flow clean`, the output showed frozen spinner characters (⠋, ⠴, ⠇) instead of tick marks (✓) for sub-steps:

```
⠋ Cleaning up sandbox› Stopping MCP host command server
› Stopping container cbox-cbox-do-whatever-claude
⠴ Cleaning up sandbox› Removing network cbox-cbox-do-whatever
⠇ Cleaning up sandbox› Removing worktree at /Users/rich/Code/cbox--do-whatever
```

## Root Cause

`sandbox.Clean()` internally calls `output.Progress()` for each sub-step, which writes new lines directly to stdout. When `Clean` is called inside `output.Spin()` (which manages a single-line spinner using `\r\033[2K`), these extra lines interfere with the spinner animation. The spinner can only clear/redraw its own line, so the sub-step lines persist with whatever spinner frame was active when they were printed.

## Fix

Added `sandbox.CleanQuiet()` — a variant of `Clean` that suppresses all progress/warning/success output. Updated all three workflow call sites (`FlowMerge`, `FlowClean`, `FlowAbandon`) to use `CleanQuiet` when wrapping the call in `output.Spin`. The direct `cbox clean` command continues to use the verbose `Clean` since it's not wrapped in a spinner.

## Files Changed

- `internal/sandbox/sandbox.go` — Extracted `cleanImpl(projectDir, branch, quiet)` from `Clean`, added `CleanQuiet` public function
- `internal/workflow/workflow.go` — Changed 3 call sites from `sandbox.Clean` to `sandbox.CleanQuiet`
- `internal/sandbox/sandbox_test.go` — Added `TestCleanQuietRemovesState` test

## Expected Output After Fix

```
✓ Cleaning up sandbox
✓ Flow 'Unclear task request' abandoned.
```