### PR TITLE
Prevent flow merge without open PR

### DIFF
--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -468,8 +468,14 @@ func FlowMerge(projectDir, branch string) error {
 
 	wf := cfg.Workflow
 
+	// Require a PR before allowing merge — without this check, merge
+	// would clean up the sandbox and destroy uncommitted work.
+	if state.PRURL == "" {
+		return fmt.Errorf("no PR has been created for branch %q — run `cbox flow pr %s` first", branch, branch)
+	}
+
 	// Merge PR
-	if state.PRURL != "" && wf != nil && wf.PR != nil && wf.PR.Merge != "" {
+	if wf != nil && wf.PR != nil && wf.PR.Merge != "" {
 		prNumber := state.PRNumber
 		if prNumber == "" {
 			// Fallback: extract from URL for old state files


### PR DESCRIPTION
## Problem

Running `cbox flow merge <branch>` before `cbox flow pr <branch>` would skip the merge step (with only a warning) but then proceed to clean up the sandbox — deleting the worktree, flow state, and reports. This destroyed all work with no way to recover.

## Fix

Added an early check in `FlowMerge()` (`internal/workflow/workflow.go:471-475`) that returns an error immediately if `state.PRURL` is empty, before any cleanup occurs. The error message tells the user to run `cbox flow pr <branch>` first.

The existing `state.PRURL != ""` condition in the merge block was simplified since the early return already guarantees a PR URL exists by the time we reach the merge logic.

## Tests added

- `TestFlowMerge_RejectsWithoutPR` — verifies that merging without a PR returns an error containing the right message, and that flow state is preserved (no cleanup).
- `TestFlowMerge_ProceedsWithPR` — verifies that merging with a PR URL does not trigger the new guard.

## Files changed

- `internal/workflow/workflow.go` — added early return error check
- `internal/workflow/workflow_test.go` — added 2 test cases