### PR TITLE
Add version flag and build system with justfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 ## Build
 
+With [just](https://github.com/casey/just):
+
+```
+just build
+```
+
+Or manually with ldflags to embed the version:
+
+```
+go build -ldflags '-s -w -X main.version=v0.0.1-alpha' -o bin/cbox ./cmd/cbox
+```
+
+Plain build (version falls back to git commit hash or "dev"):
+
 ```
 go build -o bin/cbox ./cmd/cbox
 ```

--- a/cmd/cbox/version_test.go
+++ b/cmd/cbox/version_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestResolveVersion_Fallback(t *testing.T) {
+	// When version is not set via ldflags, resolveVersion should return
+	// either a git short hash or "dev" — never an empty string.
+	v := resolveVersion()
+	if v == "" {
+		t.Fatal("resolveVersion() returned empty string")
+	}
+}
+
+func TestResolveVersion_LdflagsOverride(t *testing.T) {
+	// When version is set via ldflags, it should be returned as-is.
+	old := version
+	version = "v1.2.3-test"
+	defer func() { version = old }()
+
+	v := resolveVersion()
+	if v != "v1.2.3-test" {
+		t.Errorf("resolveVersion() = %q, want %q", v, "v1.2.3-test")
+	}
+}
+
+func TestRootCmd_VersionFlag(t *testing.T) {
+	old := version
+	version = "v0.0.1-test"
+	defer func() { version = old }()
+
+	root := buildRootCmd()
+
+	buf := new(bytes.Buffer)
+	root.SetOut(buf)
+	root.SetArgs([]string{"--version"})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("--version returned error: %v", err)
+	}
+
+	got := buf.String()
+	if got == "" {
+		t.Fatal("--version produced no output")
+	}
+	// cobra outputs "cbox version v0.0.1-test\n"
+	want := "cbox version v0.0.1-test\n"
+	if got != want {
+		t.Errorf("--version output = %q, want %q", got, want)
+	}
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,26 @@
+# cbox justfile — build system for the cbox CLI
+
+# Resolve version: git tag > short commit hash > "dev"
+version := `git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD 2>/dev/null || echo dev`
+
+ldflags := "-s -w -X main.version=" + version
+
+# Build the cbox binary
+build:
+    go build -ldflags '{{ldflags}}' -o bin/cbox ./cmd/cbox
+
+# Run all tests
+test:
+    go test ./...
+
+# Install cbox to $GOPATH/bin
+install:
+    go install -ldflags '{{ldflags}}' ./cmd/cbox
+
+# Remove build artifacts
+clean:
+    rm -rf bin/
+
+# Print the version that would be embedded
+show-version:
+    @echo {{version}}


### PR DESCRIPTION
## Summary

Re-implemented the version flag and justfile build system as specified.

## Files changed

- **cmd/cbox/main.go** — Added `version` variable (set via `-ldflags "-X main.version=..."`) with `resolveVersion()` fallback chain: ldflags value → git tag → short commit hash → `"dev"`. Extracted `buildRootCmd()` for testability. Cobra's built-in `Version` field provides `--version` flag support.
- **cmd/cbox/version_test.go** (new) — Tests for `resolveVersion()` fallback behavior, ldflags override, and `--version` flag output via the root command.
- **justfile** (new) — Build system with recipes: `build`, `test`, `install`, `clean`, `show-version`. Automatically resolves version from git tags/commit hash and passes it via ldflags.
- **CLAUDE.md** — Updated build docs to document `just build`, manual ldflags usage, and plain build fallback.

## How to test

```bash
# With just:
just build
./bin/cbox --version
just show-version

# Or manually:
go build -ldflags '-s -w -X main.version=v0.0.1-alpha' -o bin/cbox ./cmd/cbox
./bin/cbox --version

# Without a tag, falls back to short commit hash or "dev"
go build -o bin/cbox ./cmd/cbox
./bin/cbox --version
```

## Tests

All existing and new tests pass (`go test ./...`).