### PR TITLE
Add GitHub release publishing with multi-arch builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go test ./...
+
+      - run: go build ./cmd/cbox

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,28 @@
+version: 2
+
+builds:
+  - main: ./cmd/cbox
+    binary: cbox
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "cbox_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    files:
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+release:
+  mode: keep-existing


### PR DESCRIPTION
## What was done

Created three files to enable automated release publishing:

### `.goreleaser.yml`
- GoReleaser v2 config building `./cmd/cbox`
- Static binaries (`CGO_ENABLED=0`) with version embedded via ldflags (matching existing justfile pattern)
- Targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64` (4 binaries)
- Windows excluded — codebase uses Unix-only syscalls (`syscall.Exec`, `syscall.SIGTERM`, `syscall.Setpgid`)
- `tar.gz` archives named `cbox_{version}_{os}_{arch}` with README.md included
- SHA256 checksums in `checksums.txt`
- `release.mode: keep-existing` — attaches assets to the existing GitHub release without overwriting release notes

### `.github/workflows/release.yml`
- Triggers on `release: types: [created]`
- Checks out with full history, sets up Go from `go.mod`, runs GoReleaser
- Uses `GITHUB_TOKEN` for asset uploads

### `.github/workflows/test.yml`
- Triggers on push to main and PRs targeting main
- Runs `go test ./...` and `go build ./cmd/cbox`

## Verification
- `cbox_build` passes
- `cbox_test` passes

## Usage
After merge, create a GitHub release (e.g. tag `v0.1.0`) to trigger the workflow. It will upload:
```
cbox_0.1.0_linux_amd64.tar.gz
cbox_0.1.0_linux_arm64.tar.gz
cbox_0.1.0_darwin_amd64.tar.gz
cbox_0.1.0_darwin_arm64.tar.gz
checksums.txt
```