### PR TITLE
Terminal input forwarding issues in cbox containers

### DIFF
--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -1,12 +1,79 @@
 package docker
 
 import (
+	"os"
 	"os/exec"
 	"testing"
 )
 
 func hasDocker() bool {
 	return exec.Command("docker", "info").Run() == nil
+}
+
+// TestTerminalEnvArgs verifies that terminalEnvArgs returns -e flags only for
+// terminal env vars that are actually set in the environment.
+func TestTerminalEnvArgs(t *testing.T) {
+	// Clear all terminal env vars to start from a known state.
+	termVars := []string{
+		"COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION",
+		"LC_TERMINAL", "LC_TERMINAL_VERSION",
+		"KITTY_WINDOW_ID", "KITTY_PID", "ITERM_SESSION_ID",
+		"WT_SESSION", "WT_PROFILE_ID", "TERMINAL_EMULATOR",
+		"WEZTERM_PANE", "KONSOLE_VERSION", "VTE_VERSION",
+	}
+	for _, v := range termVars {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
+
+	// With nothing set, should return nil.
+	args := terminalEnvArgs()
+	if len(args) != 0 {
+		t.Errorf("expected no args when no vars set, got %v", args)
+	}
+
+	// Set a couple of vars and verify the output.
+	t.Setenv("TERM_PROGRAM", "iTerm2")
+	t.Setenv("COLORTERM", "truecolor")
+
+	args = terminalEnvArgs()
+	expected := []string{"-e", "COLORTERM=truecolor", "-e", "TERM_PROGRAM=iTerm2"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
+}
+
+// TestTerminalEnvArgsSingleVar verifies correct output when exactly one var is set.
+func TestTerminalEnvArgsSingleVar(t *testing.T) {
+	termVars := []string{
+		"COLORTERM", "TERM_PROGRAM", "TERM_PROGRAM_VERSION",
+		"LC_TERMINAL", "LC_TERMINAL_VERSION",
+		"KITTY_WINDOW_ID", "KITTY_PID", "ITERM_SESSION_ID",
+		"WT_SESSION", "WT_PROFILE_ID", "TERMINAL_EMULATOR",
+		"WEZTERM_PANE", "KONSOLE_VERSION", "VTE_VERSION",
+	}
+	for _, v := range termVars {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
+
+	t.Setenv("KITTY_WINDOW_ID", "42")
+
+	args := terminalEnvArgs()
+	expected := []string{"-e", "KITTY_WINDOW_ID=42"}
+	if len(args) != len(expected) {
+		t.Fatalf("expected %d args, got %d: %v", len(expected), len(args), args)
+	}
+	for i, want := range expected {
+		if args[i] != want {
+			t.Errorf("args[%d] = %q, want %q", i, args[i], want)
+		}
+	}
 }
 
 // TestStopAndRemoveNonExistent verifies that StopAndRemove returns nil when


### PR DESCRIPTION
## Summary

Added forwarding of terminal-identification environment variables from the host into `docker exec` calls, fixing the Shift+Enter issue in cbox containers.

## Changes

### `internal/docker/container.go`
- Added `terminalEnvArgs()` helper that collects 14 terminal-related env vars (`TERM_PROGRAM`, `COLORTERM`, `KITTY_WINDOW_ID`, `ITERM_SESSION_ID`, etc.) from the host environment and returns `-e KEY=VALUE` flags for `docker exec`
- Updated `Shell()` to inject terminal env vars into the `docker exec` args
- Updated `Chat()` to inject terminal env vars into the `docker exec` args

### `internal/docker/container_test.go`
- Added `TestTerminalEnvArgs` — verifies correct `-e` flags when multiple vars are set, and empty result when none are set
- Added `TestTerminalEnvArgsSingleVar` — verifies correct output with exactly one var set

## Root cause

`docker exec -it` only forwards the `TERM` env var automatically. Terminal emulator identification vars (like `TERM_PROGRAM=iTerm2` or `KITTY_WINDOW_ID=42`) were lost, preventing Claude Code from detecting the terminal and enabling enhanced keyboard protocols (kitty keyboard protocol) where Shift+Enter inserts a newline.

## Drag-and-drop note

File drag-and-drop is a filesystem isolation issue — the host file path doesn't exist inside the container. Forwarding terminal env vars may partially help for terminals with inline file transfer protocols (iTerm2, kitty, WezTerm), but the core limitation remains.

## Verification

- `cbox_build`: passes
- `cbox_test`: passes (including new tests)