### PR TITLE
Test timeout in TestFindMergedFlows_Empty workflow

### DIFF
--- a/internal/workflow/workflow.go
+++ b/internal/workflow/workflow.go
@@ -723,6 +723,10 @@ func flowClean(projectDir string, confirmReader io.Reader) error {
 // findMergedFlows fetches PR status for all flows concurrently and returns
 // those whose PRs are in the MERGED state.
 func findMergedFlows(wf *config.WorkflowConfig, states []*FlowState) []*FlowState {
+	if len(states) == 0 {
+		return nil
+	}
+
 	type flowResult struct {
 		state  *FlowState
 		merged bool

--- a/internal/workflow/workflow_test.go
+++ b/internal/workflow/workflow_test.go
@@ -144,7 +144,7 @@ func TestResolveOpenCommand(t *testing.T) {
 func TestFindMergedFlows(t *testing.T) {
 	wf := &config.WorkflowConfig{
 		PR: &config.WorkflowPRConfig{
-			View: `echo '{"number":$PRNumber,"state":"MERGED","title":"t","url":"u","mergedAt":"2025-01-01"}'`,
+			View: `echo "{\"number\":$PRNumber,\"state\":\"MERGED\",\"title\":\"t\",\"url\":\"u\",\"mergedAt\":\"2025-01-01\"}"`,
 		},
 	}
 
@@ -224,10 +224,12 @@ func setupFlowCleanDir(t *testing.T, viewCmd string, states []*FlowState) string
 	t.Helper()
 	dir := t.TempDir()
 
-	// Write cbox.toml
+	// Write cbox.toml — escape double quotes and backslashes for TOML basic string
+	escaped := strings.ReplaceAll(viewCmd, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 	toml := `[workflow]
 [workflow.pr]
-view = ` + `"` + viewCmd + `"` + "\n"
+view = ` + `"` + escaped + `"` + "\n"
 	if err := os.WriteFile(filepath.Join(dir, config.ConfigFile), []byte(toml), 0644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

Fixed three test failures in `internal/workflow` that caused CI to fail:

### Bug 1: `TestFindMergedFlows_Empty` — 10-minute timeout
**Root cause:** `findMergedFlows()` created a `LineSpinner(0)` when called with an empty/nil states slice. With zero lines, no line could ever be resolved, so `spinner.Run()` blocked forever waiting on a channel that would never close.

**Fix:** Added an early return at the top of `findMergedFlows()` when `len(states) == 0` (`workflow.go:726-728`).

### Bug 2: `TestFindMergedFlows` — expected 1 merged flow, got 0
**Root cause:** The test's view command used `$PRNumber` inside shell single quotes (`echo '{"number":$PRNumber,...}'`), which prevents shell variable expansion. The JSON output contained the literal string `$PRNumber` instead of `1`, causing `parsePRJSON` to fail, so no flow was marked as merged.

**Fix:** Changed the echo to use double quotes with escaped inner quotes so the shell expands `$PRNumber` from the environment variable (`workflow_test.go:147`).

### Bug 3: `TestFlowClean_*` — TOML parse errors (6 tests)
**Root cause:** `setupFlowCleanDir()` embedded view commands containing JSON (with double quotes) directly into a TOML basic string without escaping. This produced invalid TOML like `view = "echo '{"number":1,...}'"`.

**Fix:** Added escaping of backslashes and double quotes in the view command before embedding it in the TOML string (`workflow_test.go:228-229`).

### Files changed
- `internal/workflow/workflow.go` — early return in `findMergedFlows`
- `internal/workflow/workflow_test.go` — shell quoting fix + TOML escaping fix

All tests pass (`go test ./...`).