### PR TITLE
MCP response optimization: stream logs to files instead of context

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -242,7 +242,11 @@ IMPORTANT:
 These MCP tools run on the host and are your primary way to build, test, and run the project:
 %s
 
-Use these instead of trying to run build/test commands directly in the container.`, strings.Join(lines, "\n")))
+Use these instead of trying to run build/test commands directly in the container.
+
+Command output is saved to log files under `+"`"+`.cbox/logs/`+"`"+` in the worktree (e.g. `+"`"+`.cbox/logs/build.log`+"`"+`).
+The tool response contains the exit code and log path. On failure, the last 20 lines of
+output are included. To see full output, read the log file at `+"`"+`/workspace/.cbox/logs/<name>.log`+"`"+`.`, strings.Join(lines, "\n")))
 	}
 
 	// Self-healing section


### PR DESCRIPTION
## Summary

Named project commands (`cbox_build`, `cbox_test`, `cbox_run`) now write their output to log files instead of returning it inline in the MCP response. This prevents large command output (~14k+ tokens) from filling the agent's context window.

## Changes

### `internal/hostcmd/server.go`
- `makeNamedCommandHandler` now accepts a `name` parameter and writes combined stdout/stderr to `.cbox/logs/<name>.log` in the worktree
- Creates the log directory (`.cbox/logs/`) if it doesn't exist
- **Success response:** `exit_code: 0\nlog: .cbox/logs/<name>.log`
- **Failure response:** `exit_code: N\nlog: .cbox/logs/<name>.log\n\n<last 20 lines of output>` — the tail saves the agent a round-trip for common errors
- Added `lastNLines` helper function
- Updated call site in `Start()` to pass `name` to `makeNamedCommandHandler`

### `internal/docker/container.go`
- Updated the "Project Commands" section of the injected CLAUDE.md to document that output is saved to log files and how to read them at `/workspace/.cbox/logs/<name>.log`

### `internal/hostcmd/server_test.go`
- Updated `TestNamedCommandExecutes`: asserts response contains exit code and log path, does NOT contain inline output
- Updated `TestNamedCommandFailure`: asserts response contains exit code and log path
- Added `TestNamedCommandLogFileCreated`: verifies the log file is written to disk with correct content
- Added `TestNamedCommandFailureTail`: generates 30 lines, verifies response includes only the last 20

## Verification
- `cbox_build` passes (exit code 0)
- `cbox_test` passes (all tests green)