### PR TITLE
Branch naming inconsistency with worktree creation

### DIFF
--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -6,6 +6,47 @@ import (
 	"testing"
 )
 
+func TestGitWorktreeName(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a worktree-style .git file
+	if err := os.WriteFile(filepath.Join(dir, ".git"),
+		[]byte("gitdir: /Users/rich/Code/myproject/.git/worktrees/feature-branch\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	name, err := GitWorktreeName(dir)
+	if err != nil {
+		t.Fatalf("GitWorktreeName: %v", err)
+	}
+	if name != "feature-branch" {
+		t.Errorf("got %q, want %q", name, "feature-branch")
+	}
+}
+
+func TestGitWorktreeName_NotWorktree(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a .git directory (not a file) to simulate a regular repo
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := GitWorktreeName(dir)
+	if err == nil {
+		t.Error("expected error for non-worktree .git directory")
+	}
+}
+
+func TestGitWorktreeName_Missing(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := GitWorktreeName(dir)
+	if err == nil {
+		t.Error("expected error for missing .git")
+	}
+}
+
 func TestCopyFiles_SingleFile(t *testing.T) {
 	src := t.TempDir()
 	dst := t.TempDir()


### PR DESCRIPTION
## Problem

When cbox creates a worktree and mounts it into the Docker container, the worktree's `.git` file contains a `gitdir:` reference to the main repo using an absolute host path (e.g. `/Users/rich/Code/project/.git/worktrees/branch-name`). This path doesn't exist inside the container, so git sees no valid repository. Claude Code then runs `git init`, which:

1. Creates a standalone `.git` directory, destroying the worktree link
2. Defaults to branch `master` (Debian bookworm git default)
3. All subsequent commits go into this orphaned repo, disconnected from the original

## Fix

**Three changes across 4 files (+104 lines):**

### 1. Mount project `.git` into the container (`internal/docker/container.go`)
- Added `GitMountConfig` struct with `ProjectGitDir` and `ContainerGitFile` paths
- Modified `RunClaudeContainer` to accept `*GitMountConfig` and add two Docker volume mounts:
  - `-v <projectDir>/.git:/repo/.git` — makes the git database available
  - `-v <rewritten .git file>:/workspace/.git:ro` — shadows the worktree's `.git` file with one that points to `/repo/.git/worktrees/<name>` (read-only to prevent `git init` from overwriting it)

### 2. Set up git mounts during sandbox creation (`internal/sandbox/sandbox.go`)
- After creating the worktree, reads the `.git` file to determine the worktree name
- Writes a container-appropriate `.git` file to `.cbox/git/<branch>.gitfile`
- Passes the mount config to `RunClaudeContainer`

### 3. Worktree creation hardening (`internal/worktree/worktree.go`)
- Added `GitWorktreeName()` to read the worktree name from the `.git` file
- Added `os.RemoveAll(wtPath)` between the two `git worktree add` attempts, preventing the second from failing if the first left behind a partial directory

### 4. Tests (`internal/worktree/worktree_test.go`)
- Added 3 tests for `GitWorktreeName`: normal worktree, non-worktree `.git` directory, and missing `.git`

## How it works inside the container

```
/workspace/.git (read-only mount) → "gitdir: /repo/.git/worktrees/<name>"
/repo/.git (read-write mount)     → project's actual .git directory
```

Git follows the chain: `/workspace/.git` → `/repo/.git/worktrees/<name>/` → `commondir: ../..` → `/repo/.git/` → objects, refs, etc. All paths resolve correctly inside the container.