### PR TITLE
Handle missing conversation history in flow run

### DIFF
--- a/internal/docker/container.go
+++ b/internal/docker/container.go
@@ -443,6 +443,27 @@ func InjectFile(container, path, content string) error {
 	return nil
 }
 
+// HasConversationHistory checks if Claude Code has any conversation history
+// inside the given container. It runs `claude conversation list` and returns
+// true if any conversations exist.
+func HasConversationHistory(containerName string) (bool, error) {
+	cmd := exec.Command("docker", "exec", "-u", "claude", containerName,
+		"claude", "conversation", "list", "--output-format", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return false, fmt.Errorf("checking conversation history: %w", err)
+	}
+
+	return parseConversationList(out), nil
+}
+
+// parseConversationList returns true if the output from
+// `claude conversation list --output-format json` contains any conversations.
+func parseConversationList(output []byte) bool {
+	trimmed := strings.TrimSpace(string(output))
+	return trimmed != "" && trimmed != "[]"
+}
+
 // IsRunning checks if a container is currently running.
 func IsRunning(name string) (bool, error) {
 	cmd := exec.Command("docker", "inspect", "-f", "{{.State.Running}}", name)

--- a/internal/docker/container_test.go
+++ b/internal/docker/container_test.go
@@ -208,6 +208,30 @@ func TestBuildClaudeMD_SetupInHelpText(t *testing.T) {
 	}
 }
 
+// TestParseConversationList verifies parsing of claude conversation list output.
+func TestParseConversationList(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{"empty output", "", false},
+		{"empty array", "[]", false},
+		{"empty array with whitespace", "  []  \n", false},
+		{"has conversations", `[{"id":"abc123","title":"test"}]`, true},
+		{"whitespace with content", `  [{"id":"abc123"}]  `, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseConversationList([]byte(tt.output))
+			if got != tt.want {
+				t.Errorf("parseConversationList(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestStopAndRemoveNonExistent verifies that StopAndRemove returns nil when
 // the container does not exist (rather than leaking an error).
 func TestStopAndRemoveNonExistent(t *testing.T) {

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -286,6 +286,17 @@ func ChatPrompt(projectDir, branch, prompt string) error {
 	return docker.ChatPrompt(state.ClaudeContainer, prompt)
 }
 
+// HasConversationHistory checks if Claude Code has any conversation history
+// for the sandbox on the given branch.
+func HasConversationHistory(projectDir, branch string) (bool, error) {
+	state, err := LoadState(projectDir, branch)
+	if err != nil {
+		return false, err
+	}
+
+	return docker.HasConversationHistory(state.ClaudeContainer)
+}
+
 // Shell opens an interactive shell in the Claude container.
 func Shell(projectDir, branch string) error {
 	state, err := LoadState(projectDir, branch)

--- a/internal/workflow/flow_run.go
+++ b/internal/workflow/flow_run.go
@@ -72,8 +72,20 @@ func FlowRun(projectDir, branch string, yolo bool) error {
 		return FlowPR(projectDir, branch)
 	}
 
-	// Interactive: resume if already implementing, otherwise start fresh
+	// Interactive: resume if already implementing and conversation history exists
 	resume := alreadyImplementing
+	if resume {
+		hasHistory, err := sandbox.HasConversationHistory(projectDir, branch)
+		if err != nil {
+			output.Warning("Could not check conversation history: %v", err)
+			hasHistory = false
+		}
+		if !hasHistory {
+			output.Warning("No conversation history found — starting fresh session")
+			resume = false
+		}
+	}
+
 	var initialPrompt string
 	if !resume {
 		initialPrompt = prompt


### PR DESCRIPTION
## Changes

### `internal/docker/container.go`
- Added `HasConversationHistory(containerName)` — runs `docker exec claude conversation list --output-format json` and checks if any conversations exist
- Extracted `parseConversationList(output)` helper for testability

### `internal/sandbox/sandbox.go`
- Added `HasConversationHistory(projectDir, branch)` — thin wrapper that loads sandbox state and delegates to `docker.HasConversationHistory`

### `internal/workflow/flow_run.go`
- Updated `FlowRun` to check for conversation history before deciding to resume
- When history is missing (e.g., container rebuilt), falls back to a fresh session with the full implementation prompt
- Errors in the check are non-fatal (logged as warning, treated as no history)

### `internal/docker/container_test.go`
- Added `TestParseConversationList` with table-driven tests covering: empty output, empty array, whitespace variations, and valid conversation data

## Acceptance Criteria
- [x] History exists → uses `--continue` (unchanged behavior)
- [x] History missing → starts fresh with implementation prompt
- [x] Warning displayed on fallback
- [x] Task phase unchanged (remains `implementation`)
- [x] Errors are non-fatal
- [x] All tests pass
- [x] Unit tests for history check