### PR TITLE
Make yolo mode open editor like normal mode

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -634,10 +634,22 @@ func flowNewCmd() *cobra.Command {
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if yolo {
-				if len(args) == 0 {
-					return fmt.Errorf("description is required with --yolo")
+				var description string
+				if len(args) > 0 {
+					description = args[0]
+				} else {
+					cfg, _ := config.Load(projectDir())
+					var editorCfg string
+					if cfg != nil {
+						editorCfg = cfg.Editor
+					}
+					var err error
+					description, err = workflow.EditDescription(editorCfg)
+					if err != nil {
+						return err
+					}
 				}
-				return workflow.FlowNewYolo(projectDir(), args[0])
+				return workflow.FlowNewYolo(projectDir(), description)
 			}
 
 			var description string


### PR DESCRIPTION
## Changes

Modified `cmd/cbox/main.go` in `flowNewCmd()` to remove the requirement that `--yolo` must have a description argument. When `cbox flow new --yolo` is run without a description, the editor opens (using the same resolution chain as normal mode: `CBOX_EDITOR` > `cbox.toml editor` > `VISUAL` > `EDITOR`), and after the editor closes, the yolo pipeline proceeds with the collected description.

## Acceptance Criteria

- [x] `cbox flow new --yolo "some description"` continues to work exactly as before
- [x] `cbox flow new --yolo` (without description) opens the configured editor
- [x] After editor closes, full yolo pipeline runs (polish, branch, sandbox, plan, implement, PR)
- [x] Empty description from editor aborts with error (same as normal mode — handled by `EditDescription`)
- [x] Editor resolution uses same priority chain as normal mode
- [x] All existing tests pass (`go test ./...` — all packages OK)