### PR TITLE
Fix workflow state transitions and improve recovery handling

### DIFF
--- a/cmd/cbox/main.go
+++ b/cmd/cbox/main.go
@@ -603,6 +603,7 @@ func flowCmd() *cobra.Command {
 	cmd.AddCommand(flowInitCmd())
 	cmd.AddCommand(flowNewCmd())
 	cmd.AddCommand(flowShapeCmd())
+	cmd.AddCommand(flowReadyCmd())
 	cmd.AddCommand(flowRunCmd())
 	cmd.AddCommand(flowOpenCmd())
 	cmd.AddCommand(flowStatusCmd())
@@ -683,6 +684,18 @@ func flowShapeCmd() *cobra.Command {
 		ValidArgsFunction: flowCompletion(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return workflow.FlowShape(projectDir(), args[0])
+		},
+	}
+}
+
+func flowReadyCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:               "ready <branch>",
+		Short:             "Mark shaping as complete and advance to ready phase",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: flowCompletion(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workflow.FlowReady(projectDir(), args[0])
 		},
 	}
 }

--- a/internal/workflow/flow_ready.go
+++ b/internal/workflow/flow_ready.go
@@ -1,0 +1,38 @@
+package workflow
+
+import (
+	"fmt"
+
+	"github.com/richvanbergen/cbox/internal/config"
+	"github.com/richvanbergen/cbox/internal/sandbox"
+)
+
+// FlowReady marks the shaping phase as complete and advances to ready.
+// Validates that the task is in shaping phase and a plan exists.
+func FlowReady(projectDir, branch string) error {
+	cfg, err := config.Load(projectDir)
+	if err != nil {
+		return err
+	}
+
+	sandboxState, err := sandbox.LoadState(projectDir, branch)
+	if err != nil {
+		return fmt.Errorf("loading sandbox state: %w", err)
+	}
+	wtPath := sandboxState.WorktreePath
+
+	task, err := LoadTask(wtPath)
+	if err != nil {
+		return fmt.Errorf("loading task: %w", err)
+	}
+
+	if task.Phase != PhaseShaping {
+		return fmt.Errorf("task is in phase %q — must be in shaping to mark ready", task.Phase)
+	}
+
+	if !planExists(wtPath) {
+		return fmt.Errorf("no plan found — write a plan before marking ready")
+	}
+
+	return task.SetPhase(wtPath, PhaseReady, cfg.Workflow)
+}

--- a/internal/workflow/flow_run_test.go
+++ b/internal/workflow/flow_run_test.go
@@ -96,32 +96,6 @@ func TestBuildImplementationPrompt_NoUnexpandedVars(t *testing.T) {
 	}
 }
 
-func TestFormatVerifyFailures_Empty(t *testing.T) {
-	result := formatVerifyFailures(nil)
-	if result != "" {
-		t.Errorf("expected empty string for nil failures, got %q", result)
-	}
-
-	result = formatVerifyFailures([]VerifyFailure{})
-	if result != "" {
-		t.Errorf("expected empty string for empty failures, got %q", result)
-	}
-}
-
-func TestFormatVerifyFailures_WithEntries(t *testing.T) {
-	failures := []VerifyFailure{
-		{Reason: "Tests fail", Timestamp: time.Date(2025, 2, 18, 10, 0, 0, 0, time.UTC)},
-	}
-	result := formatVerifyFailures(failures)
-
-	if !strings.Contains(result, "Tests fail") {
-		t.Error("should contain failure reason")
-	}
-	if !strings.Contains(result, "2025-02-18") {
-		t.Error("should contain timestamp")
-	}
-}
-
 func TestPlanExists(t *testing.T) {
 	dir := t.TempDir()
 
@@ -138,52 +112,6 @@ func TestPlanExists(t *testing.T) {
 	if !planExists(dir) {
 		t.Error("planExists should return true after creating plan")
 	}
-}
-
-func TestAdvanceTaskToVerification(t *testing.T) {
-	dir := t.TempDir()
-
-	task := NewTask("test", "test", "Test", "Description")
-	task.Phase = PhaseImplementation
-	if err := SaveTask(dir, task); err != nil {
-		t.Fatalf("SaveTask failed: %v", err)
-	}
-
-	advanceTaskToVerification(dir, nil)
-
-	loaded, err := LoadTask(dir)
-	if err != nil {
-		t.Fatalf("LoadTask failed: %v", err)
-	}
-	if loaded.Phase != PhaseVerification {
-		t.Errorf("phase = %q, want %q", loaded.Phase, PhaseVerification)
-	}
-}
-
-func TestAdvanceTaskToVerification_SkipsWhenNotImplementation(t *testing.T) {
-	dir := t.TempDir()
-
-	task := NewTask("test", "test", "Test", "Description")
-	task.Phase = PhaseShaping
-	if err := SaveTask(dir, task); err != nil {
-		t.Fatalf("SaveTask failed: %v", err)
-	}
-
-	advanceTaskToVerification(dir, nil)
-
-	loaded, err := LoadTask(dir)
-	if err != nil {
-		t.Fatalf("LoadTask failed: %v", err)
-	}
-	if loaded.Phase != PhaseShaping {
-		t.Errorf("phase should still be shaping, got %q", loaded.Phase)
-	}
-}
-
-func TestAdvanceTaskToVerification_NoTaskFile(t *testing.T) {
-	dir := t.TempDir()
-	// Should not panic when no task.json exists
-	advanceTaskToVerification(dir, nil)
 }
 
 func TestFlowRun_PhaseValidation(t *testing.T) {

--- a/internal/workflow/flow_shape_test.go
+++ b/internal/workflow/flow_shape_test.go
@@ -93,8 +93,8 @@ func TestBuildShapingPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "Acceptance Criteria") {
 		t.Error("prompt should mention acceptance criteria")
 	}
-	if !strings.Contains(prompt, `"ready"`) {
-		t.Error("prompt should instruct advancing to ready phase")
+	if !strings.Contains(prompt, "cbox_flow_ready") {
+		t.Error("prompt should instruct calling cbox_flow_ready MCP tool")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixed all workflow state transition bypasses and added PR reconciliation for recovery from external state changes.

### Changes

**Part 1: Fix direct phase assignments**

- **FlowPR** (`workflow.go`): Replaced direct `task.Phase = PhaseVerification` with `task.SetPhase()`. PR info (URL, number) is saved first, then phase transition happens through the proper channel.
- **FlowVerifyPass** (`flow_verify.go`): Replaced direct `task.Phase = PhaseDone` with `task.SetPhase()`. Early return guard for already-done tasks remains.
- **FlowVerifyFail** (`flow_verify.go`): Saves verify failures first (so syncMemory sees them), then calls `task.SetPhase()`. Handles already-in-implementation case by skipping SetPhase (idempotent).

**Part 2: New `cbox flow ready` command and MCP tool**

- New `FlowReady()` function in `flow_ready.go` — validates task is in shaping phase and plan exists, then calls `SetPhase(PhaseReady)`.
- New `cbox flow ready <branch>` CLI subcommand in `main.go`.
- New `cbox_flow_ready` MCP tool in `server.go` — shells out to `cbox flow ready` (same pattern as `cbox_flow_pr`).
- Updated shaping prompt to instruct Claude to call `cbox_flow_ready` instead of directly editing `task.json`.

**Part 3: State recovery and reconciliation**

- New `reconcileWithPR()` function in `workflow.go` — checks remote PR state and auto-advances to done if PR is merged.
- Called in `FlowStatus` (single-branch view) to detect and fix stale state.
- Added PR merge checks in `FlowRun` and `FlowShape` to block re-entry on merged branches.

**Part 4: Dead code cleanup**

- Removed `advanceTaskToVerification()` from `flow_run.go` (never called).
- Removed `formatVerifyFailures()` from `flow_run.go` (never called in production).
- Removed corresponding tests for both functions.
- Updated shaping prompt test to check for `cbox_flow_ready` instead of `"ready"`.

### Files modified

1. `internal/workflow/workflow.go` — FlowPR fix, reconcileWithPR, FlowStatus reconciliation
2. `internal/workflow/flow_verify.go` — FlowVerifyPass and FlowVerifyFail fixes
3. `internal/workflow/flow_run.go` — Dead code removal, PR merge check
4. `internal/workflow/flow_shape.go` — Updated prompt, PR merge check
5. `internal/workflow/flow_ready.go` — New file: FlowReady function
6. `internal/hostcmd/server.go` — New cbox_flow_ready MCP tool
7. `cmd/cbox/main.go` — New flow ready CLI subcommand
8. `internal/workflow/flow_run_test.go` — Removed dead code tests
9. `internal/workflow/flow_shape_test.go` — Updated prompt assertion

### Test results

All tests pass (`go test ./...`).